### PR TITLE
fix: support repositories within subgroups

### DIFF
--- a/lib/get-repo-id.js
+++ b/lib/get-repo-id.js
@@ -1,0 +1,10 @@
+const parsePath = require('parse-path');
+const escapeStringRegexp = require('escape-string-regexp');
+
+module.exports = (gitlabUrl, repositoryUrl) => {
+  return parsePath(repositoryUrl)
+    .pathname.replace(new RegExp(`^${escapeStringRegexp(parsePath(gitlabUrl).pathname)}`), '')
+    .replace(/^\//, '')
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '');
+};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,26 +1,27 @@
-const parseGithubUrl = require('parse-github-url');
 const urlJoin = require('url-join');
 const got = require('got');
-const debug = require('debug')('semantic-release:github');
+const debug = require('debug')('semantic-release:gitlab');
 const resolveConfig = require('./resolve-config');
+const getRepoId = require('./get-repo-id');
 
 module.exports = async (pluginConfig, {repositoryUrl}, {gitHead, gitTag, notes}, logger) => {
   const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig);
-  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
+  const repoId = encodeURIComponent(getRepoId(gitlabUrl, repositoryUrl));
 
+  debug('repoId: %o', repoId);
   debug('release name: %o', gitTag);
   debug('release ref: %o', gitHead);
 
   try {
     // Test if the tag already exists
-    await got.get(urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${owner}%2F${repo}/repository/tags/${gitTag}`), {
+    await got.get(urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${repoId}/repository/tags/${gitTag}`), {
       json: true,
       headers: {'Private-Token': gitlabToken},
     });
     debug('The git tag %o already exists, update the release description', gitTag);
     // Update the release notes
     await got.post(
-      urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${owner}%2F${repo}/repository/tags/${gitTag}/release`),
+      urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${repoId}/repository/tags/${gitTag}/release`),
       {json: true, headers: {'Private-Token': gitlabToken}, body: {tag_name: gitTag, description: notes}} // eslint-disable-line camelcase
     );
   } catch (err) {
@@ -29,14 +30,11 @@ module.exports = async (pluginConfig, {repositoryUrl}, {gitHead, gitTag, notes},
       throw err;
     }
     debug('Create git tag %o with commit %o and release description', gitTag, gitHead);
-    await got.post(
-      urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${owner}%2F${repo}/repository/tags/${gitTag}/release`),
-      {
-        json: true,
-        headers: {'PRIVATE-TOKEN': gitlabToken},
-        body: {tag_name: gitTag, ref: gitHead, release_description: notes}, // eslint-disable-line camelcase
-      }
-    );
+    await got.post(urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${repoId}/repository/tags/${gitTag}/release`), {
+      json: true,
+      headers: {'PRIVATE-TOKEN': gitlabToken},
+      body: {tag_name: gitTag, ref: gitHead, release_description: notes}, // eslint-disable-line camelcase
+    });
   }
 
   logger.log('Published GitLab release: %s', gitTag);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,8 +1,9 @@
-const parseGithubUrl = require('parse-github-url');
 const urlJoin = require('url-join');
 const got = require('got');
+const debug = require('debug')('semantic-release:gitlab');
 const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./resolve-config');
+const getRepoId = require('./get-repo-id');
 
 module.exports = async (pluginConfig, {repositoryUrl}, logger) => {
   const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig);
@@ -11,8 +12,11 @@ module.exports = async (pluginConfig, {repositoryUrl}, logger) => {
     throw new SemanticReleaseError('No GitLab token specified.', 'ENOGLTOKEN');
   }
 
-  const {name: repo, owner} = parseGithubUrl(repositoryUrl);
-  if (!owner || !repo) {
+  const repoId = getRepoId(gitlabUrl, repositoryUrl);
+
+  debug('repoId: %o', repoId);
+
+  if (!repoId) {
     throw new SemanticReleaseError(
       `The git repository URL ${repositoryUrl} is not a valid GitLab URL.`,
       'EINVALIDGITURL'
@@ -26,21 +30,21 @@ module.exports = async (pluginConfig, {repositoryUrl}, logger) => {
 
   try {
     ({body: {permissions: {project_access: projectAccess, group_access: groupAccess}}} = await got.get(
-      urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${owner}%2F${repo}`),
+      urlJoin(gitlabUrl, gitlabApiPathPrefix, `/projects/${encodeURIComponent(repoId)}`),
       {json: true, headers: {'Private-Token': gitlabToken}}
     ));
   } catch (err) {
     if (err.statusCode === 401) {
       throw new SemanticReleaseError('Invalid GitLab token.', 'EINVALIDGLTOKEN');
     } else if (err.statusCode === 404) {
-      throw new SemanticReleaseError(`The repository ${owner}/${repo} doesn't exist.`, 'EMISSINGREPO');
+      throw new SemanticReleaseError(`The repository ${repoId} doesn't exist.`, 'EMISSINGREPO');
     }
     throw err;
   }
 
   if (!((projectAccess && projectAccess.access_level >= 30) || (groupAccess && groupAccess.access_level >= 30))) {
     throw new SemanticReleaseError(
-      `The GitLab token doesn't allow to push on the repository ${owner}/${repo}.`,
+      `The GitLab token doesn't allow to push on the repository ${repoId}.`,
       'EGHNOPERMISSION'
     );
   }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "dependencies": {
     "@semantic-release/error": "^2.1.0",
     "debug": "^3.1.0",
+    "escape-string-regexp": "^1.0.5",
     "got": "^8.0.1",
-    "parse-github-url": "^1.0.2",
+    "parse-path": "^3.0.2",
     "url-join": "^2.0.2"
   },
   "devDependencies": {

--- a/test/get-repo-id.test.js
+++ b/test/get-repo-id.test.js
@@ -1,0 +1,33 @@
+import test from 'ava';
+import getRepoId from '../lib/get-repo-id';
+
+test('Parse repo id with https URL', t => {
+  t.is(getRepoId('https://gitlbab.com', 'https://gitlab.com/owner/repo.git'), 'owner/repo');
+  t.is(getRepoId('https://gitlbab.com', 'https://gitlab.com/owner/repo'), 'owner/repo');
+});
+
+test('Parse repo id with git URL', t => {
+  t.is(getRepoId('https://gitlab.com', 'git+ssh://git@gitlab.com/owner/repo.git'), 'owner/repo');
+  t.is(getRepoId('https://gitlab.com', 'git+ssh://git@gitlab.com/owner/repo'), 'owner/repo');
+});
+
+test('Parse repo id with context in repo URL', t => {
+  t.is(getRepoId('https://gitlbab.com/context', 'https://gitlab.com/context/owner/repo.git'), 'owner/repo');
+  t.is(getRepoId('https://gitlab.com/context', 'git+ssh://git@gitlab.com/context/owner/repo.git'), 'owner/repo');
+});
+
+test('Parse repo id with context not in repo URL', t => {
+  t.is(getRepoId('https://gitlbab.com/context', 'https://gitlab.com/owner/repo.git'), 'owner/repo');
+  t.is(getRepoId('https://gitlab.com/context', 'git+ssh://git@gitlab.com/owner/repo.git'), 'owner/repo');
+});
+
+test('Parse repo id with organization and subgroup', t => {
+  t.is(
+    getRepoId('https://gitlbab.com/context', 'https://gitlab.com/orga/subgroup/owner/repo.git'),
+    'orga/subgroup/owner/repo'
+  );
+  t.is(
+    getRepoId('https://gitlab.com/context', 'git+ssh://git@gitlab.com/orga/subgroup/owner/repo.git'),
+    'orga/subgroup/owner/repo'
+  );
+});


### PR DESCRIPTION
Extract the repository id from the repository URL as follow:
- `htttp://gitlab.com/owner/repo.git` => `owner%2Frepo`
- `htttp://gitlab.com/orga/owner/repo.git` => `orga%2Fowner%2Frepo`
- `htttp://gitlab.com/orga/group/owner/repo.git` => `orga%2Fgroup%2Fowner%2Frepo`
- `htttp://custom.com/context/orga/group/owner/repo.git` => `orga%2Fgroup%2Fowner%2Frepo` (if gitlab URL is `htttp://custom.com/context`)

Also works with `git` and `git+ssh` URLs.

Fix #2 