### PR TITLE
fix(publish): encode the git tag in the release notes post so that ta…

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,13 +8,14 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, nextRelease: {g
   const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig);
   const repoId = getRepoId(gitlabUrl, repositoryUrl);
   const apiUrl = urlJoin(gitlabUrl, gitlabApiPathPrefix);
+  const gitTagEncoded = encodeURIComponent(gitTag);
 
   debug('repoId: %o', repoId);
   debug('release name: %o', gitTag);
   debug('release ref: %o', gitHead);
 
   debug('Update git tag %o with commit %o and release description', gitTag, gitHead);
-  await got.post(urlJoin(apiUrl, `/projects/${encodeURIComponent(repoId)}/repository/tags/${gitTag}/release`), {
+  await got.post(urlJoin(apiUrl, `/projects/${encodeURIComponent(repoId)}/repository/tags/${gitTagEncoded}/release`), {
     json: true,
     headers: {'PRIVATE-TOKEN': gitlabToken},
     body: {tag_name: gitTag, description: notes}, // eslint-disable-line camelcase
@@ -22,5 +23,5 @@ module.exports = async (pluginConfig, {options: {repositoryUrl}, nextRelease: {g
 
   logger.log('Published GitLab release: %s', gitTag);
 
-  return {url: urlJoin(gitlabUrl, repoId, `/tags/${gitTag}`), name: 'GitHub release'};
+  return {url: urlJoin(gitlabUrl, repoId, `/tags/${gitTagEncoded}`), name: 'GitHub release'};
 };

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -35,11 +35,12 @@ test.serial('Publish a release', async t => {
   const repo = 'test_repo';
   process.env.GITLAB_TOKEN = 'gitlab_token';
   const pluginConfig = {};
-  const nextRelease = {gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const nextRelease = {gitHead: '123', gitTag: '@scope/v1.0.0', notes: 'Test release note body'};
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
+  const gitTagEncoded = encodeURIComponent(nextRelease.gitTag);
 
   const gitlab = authenticate()
-    .post(`/projects/${owner}%2F${repo}/repository/tags/${nextRelease.gitTag}/release`, {
+    .post(`/projects/${owner}%2F${repo}/repository/tags/${gitTagEncoded}/release`, {
       tag_name: nextRelease.gitTag,
       description: nextRelease.notes,
     })
@@ -47,7 +48,7 @@ test.serial('Publish a release', async t => {
 
   const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${owner}/${repo}/tags/${nextRelease.gitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/tags/${gitTagEncoded}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });


### PR DESCRIPTION
…gs that contain a forward slash `/` — e.g. a lerna monorepo that publishes to an npm scope — don't cause a 404


-----

Fix #26