### PR TITLE
feat: use `cwd` and `env` options passed by core

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -4,8 +4,13 @@ const debug = require('debug')('semantic-release:gitlab');
 const resolveConfig = require('./resolve-config');
 const getRepoId = require('./get-repo-id');
 
-module.exports = async (pluginConfig, {options: {repositoryUrl}, nextRelease: {gitTag, gitHead, notes}, logger}) => {
-  const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig);
+module.exports = async (pluginConfig, context) => {
+  const {
+    options: {repositoryUrl},
+    nextRelease: {gitTag, gitHead, notes},
+    logger,
+  } = context;
+  const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig, context);
   const repoId = getRepoId(gitlabUrl, repositoryUrl);
   const encodedRepoId = encodeURIComponent(repoId);
   const apiUrl = urlJoin(gitlabUrl, gitlabApiPathPrefix);

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,12 +1,12 @@
-module.exports = ({gitlabUrl, gitlabApiPathPrefix}) => ({
-  gitlabToken: process.env.GL_TOKEN || process.env.GITLAB_TOKEN,
-  gitlabUrl: gitlabUrl || process.env.GL_URL || process.env.GITLAB_URL || 'https://gitlab.com',
+module.exports = ({gitlabUrl, gitlabApiPathPrefix}, {env}) => ({
+  gitlabToken: env.GL_TOKEN || env.GITLAB_TOKEN,
+  gitlabUrl: gitlabUrl || env.GL_URL || env.GITLAB_URL || 'https://gitlab.com',
   gitlabApiPathPrefix:
     typeof gitlabApiPathPrefix === 'string'
       ? gitlabApiPathPrefix
-      : null || typeof process.env.GL_PREFIX === 'string'
-        ? process.env.GL_PREFIX
-        : null || typeof process.env.GITLAB_PREFIX === 'string'
-          ? process.env.GITLAB_PREFIX
+      : null || typeof env.GL_PREFIX === 'string'
+        ? env.GL_PREFIX
+        : null || typeof env.GITLAB_PREFIX === 'string'
+          ? env.GITLAB_PREFIX
           : null || '/api/v4',
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -6,9 +6,13 @@ const resolveConfig = require('./resolve-config');
 const getRepoId = require('./get-repo-id');
 const getError = require('./get-error');
 
-module.exports = async (pluginConfig, {options: {repositoryUrl}, logger}) => {
+module.exports = async (pluginConfig, context) => {
+  const {
+    options: {repositoryUrl},
+    logger,
+  } = context;
   const errors = [];
-  const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig);
+  const {gitlabToken, gitlabUrl, gitlabApiPathPrefix} = resolveConfig(pluginConfig, context);
   const repoId = getRepoId(gitlabUrl, repositoryUrl);
   debug('repoId: %o', repoId);
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=13.3.0 <16.0.0"
+    "semantic-release": ">=15.8.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/test/helpers/mock-gitlab.js
+++ b/test/helpers/mock-gitlab.js
@@ -4,19 +4,23 @@ import urlJoin from 'url-join';
 /**
  * Retun a `nock` object setup to respond to a GitLab authentication request. Other expectation and responses can be chained.
  *
- * @param {String} [gitlabToken=process.env.GL_TOKEN || process.env.GITLAB_TOKEN || 'GL_TOKEN'] The github token to return in the authentication response.
- * @param {String} [gitlabUrl=process.env.GL_URL || process.env.GITLAB_URL || 'https://api.github.com'] The url on which to intercept http requests.
- * @param {String} [gitlabApiPathPrefix=process.env.GL_PREFIX || process.env.GITLAB_PREFIX || ''] The GitHub Enterprise API prefix.
+ * @param {Object} [env={}] Environment variables.
+ * @param {String} [gitlabToken=env.GL_TOKEN || env.GITLAB_TOKEN || 'GL_TOKEN'] The github token to return in the authentication response.
+ * @param {String} [gitlabUrl=env.GL_URL || env.GITLAB_URL || 'https://api.github.com'] The url on which to intercept http requests.
+ * @param {String} [gitlabApiPathPrefix=env.GL_PREFIX || env.GITLAB_PREFIX || ''] The GitHub Enterprise API prefix.
  * @return {Object} A `nock` object ready to respond to a github authentication request.
  */
-export default function authenticate({
-  gitlabToken = process.env.GL_TOKEN || process.env.GITLAB_TOKEN || 'GL_TOKEN',
-  gitlabUrl = process.env.GL_URL || process.env.GITLAB_URL || 'https://gitlab.com',
-  gitlabApiPathPrefix = typeof process.env.GL_PREFIX === 'string'
-    ? process.env.GL_PREFIX
-    : null || typeof process.env.GITLAB_PREFIX === 'string'
-      ? process.env.GITLAB_PREFIX
-      : null || '/api/v4',
-} = {}) {
+export default function authenticate(
+  env = {},
+  {
+    gitlabToken = env.GL_TOKEN || env.GITLAB_TOKEN || 'GL_TOKEN',
+    gitlabUrl = env.GL_URL || env.GITLAB_URL || 'https://gitlab.com',
+    gitlabApiPathPrefix = typeof env.GL_PREFIX === 'string'
+      ? env.GL_PREFIX
+      : null || typeof env.GITLAB_PREFIX === 'string'
+        ? env.GITLAB_PREFIX
+        : null || '/api/v4',
+  } = {}
+) {
   return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), {reqheaders: {'Private-Token': gitlabToken}});
 }

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -6,17 +6,7 @@ import authenticate from './helpers/mock-gitlab';
 
 /* eslint camelcase: ["error", {properties: "never"}] */
 
-// Save the current process.env
-const envBackup = Object.assign({}, process.env);
-
 test.beforeEach(t => {
-  // Delete env variables in case they are on the machine running the tests
-  delete process.env.GL_TOKEN;
-  delete process.env.GITLAB_TOKEN;
-  delete process.env.GL_URL;
-  delete process.env.GITLAB_URL;
-  delete process.env.GL_PREFIX;
-  delete process.env.GITLAB_PREFIX;
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -24,8 +14,6 @@ test.beforeEach(t => {
 });
 
 test.afterEach.always(() => {
-  // Restore process.env
-  process.env = envBackup;
   // Clear nock
   nock.cleanAll();
 });
@@ -33,21 +21,21 @@ test.afterEach.always(() => {
 test.serial('Publish a release', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';
-  process.env.GITLAB_TOKEN = 'gitlab_token';
+  const env = {GITLAB_TOKEN: 'gitlab_token'};
   const pluginConfig = {};
   const nextRelease = {gitHead: '123', gitTag: '@scope/v1.0.0', notes: 'Test release note body'};
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
   const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
 
-  const gitlab = authenticate()
+  const gitlab = authenticate(env)
     .post(`/projects/${encodedRepoId}/repository/tags/${encodedGitTag}/release`, {
       tag_name: nextRelease.gitTag,
       description: nextRelease.notes,
     })
     .reply(200);
 
-  const result = await publish(pluginConfig, {options, nextRelease, logger: t.context.logger});
+  const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
   t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.8.0`