### PR TITLE
Re-write usage phrase in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ authentication is supported.
 
 ### Usage
 
-Options can be set within the plugin definition in the Semantic-release configuration file:
+Options can be set within the plugin definition in the `package.json` file.
 
 ```json
 {


### PR DESCRIPTION
In the usage section,  'Semantic-release configuration file' was mentioned as the place to write the configuration. This phrase might mislead people into thinking that there is an additional file, other than `package.json` for writing the configuration for this tool.