### PR TITLE
feat: add asset links to release using api and remove them from markdown

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,12 +18,12 @@ module.exports = async (pluginConfig, context) => {
     logger,
   } = context;
   const {gitlabToken, gitlabUrl, gitlabApiPathPrefix, assets} = resolveConfig(pluginConfig, context);
+  const assetsList = [];
   const repoId = getRepoId(gitlabUrl, repositoryUrl);
   const encodedRepoId = encodeURIComponent(repoId);
   const encodedGitTag = encodeURIComponent(gitTag);
   const apiUrl = urlJoin(gitlabUrl, gitlabApiPathPrefix, `projects/${encodedRepoId}`);
   const apiOptions = {json: true, headers: {'PRIVATE-TOKEN': gitlabToken}};
-  let finalNotes = notes;
 
   debug('repoId: %o', repoId);
   debug('release name: %o', gitTag);
@@ -31,7 +31,6 @@ module.exports = async (pluginConfig, context) => {
 
   if (assets && assets.length > 0) {
     const globbedAssets = await getAssets(context, assets);
-    const assetsMd = [];
     debug('globbed assets: %o', globbedAssets);
 
     await Promise.all(
@@ -65,23 +64,30 @@ module.exports = async (pluginConfig, context) => {
         });
         const {url, alt} = JSON.parse(body);
 
-        // Adds markdown per asset
-        assetsMd.push(`* [${label || alt}](${url})`);
+        assetsList.push({label, alt, url});
 
         logger.log('Uploaded file: %s', url);
       })
     );
-    // Append assets to release notes
-    if (assetsMd.length > 0) {
-      finalNotes = `${notes}\n\n#### Assets\n\n${assetsMd.join('\n')}`;
-    }
   }
 
   debug('Update git tag %o with commit %o and release description', gitTag, gitHead);
   await got.post(urlJoin(apiUrl, `/repository/tags/${encodedGitTag}/release`), {
     ...apiOptions,
-    body: {tag_name: gitTag, description: finalNotes}, // eslint-disable-line camelcase
+    body: {tag_name: gitTag, description: notes}, // eslint-disable-line camelcase
   });
+
+  if (assetsList.length > 0) {
+    await Promise.all(
+      assetsList.map(({label, alt, url}) => {
+        debug('Add link to asset %o', label || alt);
+        return got.post(urlJoin(apiUrl, `/releases/${encodedGitTag}/assets/links`), {
+          ...apiOptions,
+          body: {name: label || alt, url: urlJoin(gitlabUrl, repoId, url)},
+        });
+      })
+    );
+  }
 
   logger.log('Published GitLab release: %s', gitTag);
 

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -51,18 +51,23 @@ test.serial('Publish a release with assets', async t => {
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
   const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
-  const uploaded = {markdown: '[file.css](/uploads/file.css)', url: '/uploads/file.css', alt: 'file.css'};
-  const notes = `${nextRelease.notes}\n\n#### Assets\n\n* ${uploaded.markdown}`;
+  const uploaded = {url: '/uploads/file.css', alt: 'file.css'};
   const assets = [['**', '!**/*.txt', '!.dotfile']];
   const gitlab = authenticate(env)
     .post(`/projects/${encodedRepoId}/repository/tags/${encodedGitTag}/release`, {
       tag_name: nextRelease.gitTag,
-      description: notes,
+      description: nextRelease.notes,
     })
     .reply(200);
   const gitlabUpload = authenticate(env)
     .post(`/projects/${encodedRepoId}/uploads`, /filename="file.css"/gm)
     .reply(200, uploaded);
+  const gitlabAssetLink = authenticate(env)
+    .post(`/projects/${encodedRepoId}/releases/${encodedGitTag}/assets/links`, {
+      url: `https://gitlab.com/${owner}/${repo}${uploaded.url}`,
+      name: uploaded.alt,
+    })
+    .reply(200, {});
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
@@ -71,6 +76,7 @@ test.serial('Publish a release with assets', async t => {
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
   t.true(gitlab.isDone());
+  t.true(gitlabAssetLink.isDone());
 });
 
 test.serial('Publish a release with array of missing assets', async t => {
@@ -90,7 +96,6 @@ test.serial('Publish a release with array of missing assets', async t => {
       description: nextRelease.notes,
     })
     .reply(200);
-
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
   t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
@@ -107,19 +112,24 @@ test.serial('Publish a release with one asset and custom label', async t => {
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
   const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
-  const uploaded = {markdown: '[file](/uploads/upload.txt)', url: '/uploads/upload.txt'};
+  const uploaded = {url: '/uploads/upload.txt'};
   const assetLabel = 'Custom Label';
-  const notes = `${nextRelease.notes}\n\n#### Assets\n\n* [${assetLabel}](${uploaded.url})`;
   const assets = [{path: 'upload.txt', label: assetLabel}];
   const gitlab = authenticate(env)
     .post(`/projects/${encodedRepoId}/repository/tags/${encodedGitTag}/release`, {
       tag_name: nextRelease.gitTag,
-      description: notes,
+      description: nextRelease.notes,
     })
     .reply(200);
   const gitlabUpload = authenticate(env)
     .post(`/projects/${encodedRepoId}/uploads`, /filename="upload.txt"/gm)
     .reply(200, uploaded);
+  const gitlabAssetLink = authenticate(env)
+    .post(`/projects/${encodedRepoId}/releases/${encodedGitTag}/assets/links`, {
+      url: `https://gitlab.com/${owner}/${repo}${uploaded.url}`,
+      name: assetLabel,
+    })
+    .reply(200, {});
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
@@ -128,4 +138,5 @@ test.serial('Publish a release with one asset and custom label', async t => {
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
   t.true(gitlab.isDone());
+  t.true(gitlabAssetLink.isDone());
 });


### PR DESCRIPTION
BREAKING CHANGE: require GitLab version >= `11.7`

Fix #79