### PR TITLE
fix: verify badly configured reverse proxy + more complete error mess…

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -13,22 +13,22 @@ module.exports = {
     )}) must be an \`Array\` of \`Strings\` or \`Objects\` with a \`path\` property.
 Your configuration for the \`assets\` option is \`${stringify(assets)}\`.`,
   }),
-  EINVALIDGITLABURL: () => ({
-    message: 'The git repository URL is not a valid GitLab URL.',
+  EINVALIDGITLABURL: ({gitlabUrl, repositoryUrl}) => ({
+    message: `The git repository URL "${repositoryUrl}" is not a valid URL for the GitLab instance at ${gitlabUrl}.`,
     details: `The **semantic-release** \`repositoryUrl\` option must a valid GitLab URL with the format \`<GitLab_URL>/<repoId>.git\`.
 
 By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.`,
   }),
-  EINVALIDGLTOKEN: ({repoId}) => ({
-    message: 'Invalid GitLab token.',
+  EINVALIDGLTOKEN: ({repoId, gitlabUrl}) => ({
+    message: `Invalid GitLab token for the GitLab instance at ${gitlabUrl}.`,
     details: `The [GitLab token](${linkify(
       'README.md#gitlab-authentication'
     )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must be a valid [personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html) allowing to push to the repository ${repoId}.
 
 Please make sure to set the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable in your CI with the exact value of the GitLab personal token.`,
   }),
-  EMISSINGREPO: ({repoId}) => ({
-    message: `The repository ${repoId} doesn't exist.`,
+  EMISSINGREPO: ({repoId, gitlabUrl}) => ({
+    message: `The repository ${repoId} doesn't exist for the GitLab instance at ${gitlabUrl}.`,
     details: `The **semantic-release** \`repositoryUrl\` option must refer to your GitLab repository. The repository must be accessible with the [GitLab API](https://docs.gitlab.com/ce/api/README.html).
 
 By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.
@@ -37,8 +37,15 @@ If you are using [GitLab Enterprise Edition](https://about.gitlab.com/gitlab-ee)
       'README.md#options'
     )}).`,
   }),
-  EGLNOPERMISSION: ({repoId}) => ({
-    message: `The GitLab token doesn't allow to push on the repository ${repoId}.`,
+  EUNEXPECTED404: ({repoId, repositoryApiUrl, statusMessage}) => ({
+    message: `The api call to the repository ${repoId} through url ${repositoryApiUrl} returned an unexpected 404 response with message "${statusMessage}".`,
+    details:
+      'The "Not Found" message could be caused by an incorrectly configured reverse proxy in front of your GitLab instance. ' +
+      'See issue comment https://github.com/semantic-release/gitlab/issues/63#issuecomment-527080331 for more details. ' +
+      'Other response message will require further troubleshooting.',
+  }),
+  EGLNOPERMISSION: ({repoId, gitlabUrl}) => ({
+    message: `The GitLab token doesn't allow to push on the repository ${repoId} on the GitLab instance at ${gitlabUrl}.`,
     details: `The user associated with the [GitLab token](${linkify(
       'README.md#gitlab-authentication'
     )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must allows to push to the repository ${repoId}.

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -25,10 +25,15 @@ module.exports = async (pluginConfig, context) => {
   const errors = [];
   const {gitlabToken, gitlabUrl, gitlabApiPathPrefix, assets} = resolveConfig(pluginConfig, context);
   const repoId = getRepoId(gitlabUrl, repositoryUrl);
+  debug('repositoryUrl: %s', repositoryUrl);
+  debug('gitlabToken: %s', gitlabToken);
+  debug('gitlabUrl: %s', gitlabUrl);
+  debug('gitlabApiPathPrefix: %s', gitlabApiPathPrefix);
+  debug('assets: %s', assets);
   debug('repoId: %o', repoId);
 
   if (!repoId) {
-    errors.push(getError('EINVALIDGITLABURL'));
+    errors.push(getError('EINVALIDGITLABURL', {gitlabUrl, repositoryUrl}));
   }
 
   if (assets && !VALIDATORS.assets(assets)) {
@@ -48,24 +53,32 @@ module.exports = async (pluginConfig, context) => {
 
     logger.log('Verify GitLab authentication (%s)', apiUrl);
 
+    const repositoryApiUrl = urlJoin(apiUrl, `/projects/${encodeURIComponent(repoId)}`);
+    debug('Url used for api verification call: %s', repositoryApiUrl);
+
     try {
       ({
         body: {
           permissions: {project_access: projectAccess, group_access: groupAccess},
         },
-      } = await got.get(urlJoin(apiUrl, `/projects/${encodeURIComponent(repoId)}`), {
+      } = await got.get(repositoryApiUrl, {
         json: true,
         headers: {'Private-Token': gitlabToken},
       }));
 
       if (!((projectAccess && projectAccess.access_level >= 30) || (groupAccess && groupAccess.access_level >= 30))) {
-        errors.push(getError('EGLNOPERMISSION', {repoId}));
+        errors.push(getError('EGLNOPERMISSION', {repoId, gitlabUrl}));
       }
     } catch (error) {
+      debug('Error thrown: %O', error);
       if (error.statusCode === 401) {
-        errors.push(getError('EINVALIDGLTOKEN', {repoId}));
+        errors.push(getError('EINVALIDGLTOKEN', {repoId, gitlabUrl}));
       } else if (error.statusCode === 404) {
-        errors.push(getError('EMISSINGREPO', {repoId}));
+        if (error.statusMessage === 'Project Not Found' || error.body.error.includes('Project Not Found')) {
+          errors.push(getError('EMISSINGREPO', {repoId, gitlabUrl}));
+        } else {
+          errors.push(getError('EUNEXPECTED404q', {repoId, repositoryApiUrl, statusMessage: error.statusMessage}));
+        }
       } else {
         throw error;
       }


### PR DESCRIPTION
…ages

Now throws EMISSINGREPO only when response with statusCode at 404 and statusMessage is "Project Not
Found" and throws EUNEXPECTED404 when there is a problem with a badly configured reverse-proxy
(similar response but with statusMessage is "Not Found"). Also adds information when error is thrown
to help with troubleshooting.

fix #99 and re #92