### PR TITLE
feat: support external urls in assets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/gitlab-api.js
+++ b/lib/gitlab-api.js
@@ -1,0 +1,50 @@
+const got = require('got');
+const urlJoin = require('url-join');
+
+function createGitlabApi(gitlabApiUrl, {token}) {
+  const apiOptions = {json: true, headers: {'PRIVATE-TOKEN': token}};
+
+  const links = async (repoId, gitTag, {name, url}) => {
+    const linksUrl = urlJoin(
+      gitlabApiUrl,
+      `/projects/${encodeURIComponent(repoId)}/releases/${encodeURIComponent(gitTag)}/assets/links`
+    );
+
+    return got.post(linksUrl, {
+      ...apiOptions,
+      body: {name, url},
+    });
+  };
+
+  const uploads = async (repoId, data) => {
+    const uploadsUrl = urlJoin(gitlabApiUrl, `/projects/${encodeURIComponent(repoId)}/uploads`);
+
+    const res = await got.post(uploadsUrl, {
+      ...apiOptions,
+      json: false,
+      body: data,
+    });
+
+    return JSON.parse(res.body);
+  };
+
+  const release = (repoId, gitTag, description) => {
+    const releaseUrl = urlJoin(
+      gitlabApiUrl,
+      `/projects/${encodeURIComponent(repoId)}/repository/tags/${encodeURIComponent(gitTag)}/release`
+    );
+
+    return got.post(releaseUrl, {
+      ...apiOptions,
+      body: {tag_name: gitTag, description}, // eslint-disable-line camelcase
+    });
+  };
+
+  const tagUrl = (gitlabUrl, repoId, gitTag) => {
+    return urlJoin(gitlabUrl, encodeURIComponent(repoId), `/tags/${encodeURIComponent(gitTag)}`);
+  };
+
+  return {release, links, uploads, tagUrl};
+}
+
+module.exports = createGitlabApi;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,94 +1,133 @@
 const {createReadStream} = require('fs');
 const {resolve} = require('path');
-const {stat} = require('fs-extra');
-const {isPlainObject} = require('lodash');
 const FormData = require('form-data');
-const urlJoin = require('url-join');
-const got = require('got');
 const debug = require('debug')('semantic-release:gitlab');
-const resolveConfig = require('./resolve-config');
-const getRepoId = require('./get-repo-id');
+const urlJoin = require('url-join');
+const {isPlainObject, isArray, isNil, isString, isEmpty, template} = require('lodash');
+const {statSync} = require('fs-extra');
+const createGitlabApi = require('./gitlab-api');
 const getAssets = require('./glob-assets');
+const getRepoId = require('./get-repo-id');
+const resolveConfig = require('./resolve-config');
 
-module.exports = async (pluginConfig, context) => {
+async function resolveAssets(context, assets) {
+  const globbedAssets = await getAssets(context, assets);
+  debug('globbed assets: %o', globbedAssets);
+  return globbedAssets
+    .map(asset => {
+      const {path, label} = isPlainObject(asset) ? asset : {path: asset};
+      const file = resolve(context.cwd, path);
+      return {...asset, path, label, file};
+    })
+    .filter(({file, label, path}) => {
+      let fileStat;
+
+      try {
+        fileStat = statSync(file);
+      } catch (_) {
+        context.logger.error('The asset %s cannot be read, and will be ignored.', path);
+        return false;
+      }
+
+      if (!fileStat || !fileStat.isFile()) {
+        context.logger.error('The asset %s is not a file, and will be ignored.', path);
+        return false;
+      }
+
+      debug('file path: %o', path);
+      debug('file label: %o', label);
+
+      return true;
+    });
+}
+
+function compileAssetTemplates(asset) {
+  const options = {interpolate: /{{([\s\S]+?)}}/g};
+  return {
+    ...asset,
+    // Expand name and url using `{{ }}` as delimiter
+    name: isNil(asset.name) && isNil(asset.label) ? undefined : template(asset.name || asset.label, options),
+    url: template(asset.url, options),
+  };
+}
+
+async function extractAssets(context, assets) {
+  const emptyAssets = isEmpty(assets);
+  const fileAssets = emptyAssets
+    ? []
+    : await resolveAssets(
+        context,
+        assets.filter(asset => isString(asset) || isArray(asset) || !isNil(asset.path))
+      );
+
+  const urlAssets = emptyAssets
+    ? []
+    : assets
+        .filter(asset => !isNil(asset.url))
+        .map(asset => compileAssetTemplates(asset))
+        .map(asset => {
+          const url = asset.url(context);
+          return {
+            ...asset,
+            // Default `name` to the actual `url` if missing
+            name: asset.name ? asset.name(context) : url,
+            url,
+          };
+        });
+
+  return {urlAssets, fileAssets};
+}
+
+async function publish(pluginConfig, context) {
   const {
-    cwd,
     options: {repositoryUrl},
     nextRelease: {gitTag, gitHead, notes},
     logger,
   } = context;
-  const {gitlabToken, gitlabUrl, gitlabApiUrl, assets} = resolveConfig(pluginConfig, context);
-  const assetsList = [];
+  const {gitlabUrl, assets, gitlabApiUrl, gitlabToken} = resolveConfig(pluginConfig, context);
   const repoId = getRepoId(context, gitlabUrl, repositoryUrl);
-  const encodedRepoId = encodeURIComponent(repoId);
-  const encodedGitTag = encodeURIComponent(gitTag);
-  const apiOptions = {json: true, headers: {'PRIVATE-TOKEN': gitlabToken}};
 
   debug('repoId: %o', repoId);
   debug('release name: %o', gitTag);
   debug('release ref: %o', gitHead);
 
-  if (assets && assets.length > 0) {
-    const globbedAssets = await getAssets(context, assets);
-    debug('globbed assets: %o', globbedAssets);
+  const {release, links, uploads, tagUrl} = createGitlabApi(gitlabApiUrl, {token: gitlabToken});
 
+  debug('Update git tag %o with commit %o and release description', gitTag, gitHead);
+  await release(repoId, gitTag, notes);
+
+  const {urlAssets, fileAssets} = await extractAssets(context, assets);
+
+  // Add all assets declaring a `url` property (may be a lodash template)
+  if (!isEmpty(urlAssets)) {
     await Promise.all(
-      globbedAssets.map(async asset => {
-        const {path, label} = isPlainObject(asset) ? asset : {path: asset};
-        const file = resolve(cwd, path);
-        let fileStat;
-
-        try {
-          fileStat = await stat(file);
-        } catch (_) {
-          logger.error('The asset %s cannot be read, and will be ignored.', path);
-          return;
-        }
-
-        if (!fileStat || !fileStat.isFile()) {
-          logger.error('The asset %s is not a file, and will be ignored.', path);
-          return;
-        }
-
-        debug('file path: %o', path);
-        debug('file label: %o', label);
-
-        // Uploaded assets to the project
-        const form = new FormData();
-        form.append('file', createReadStream(file));
-        const {body} = await got.post(urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/uploads`), {
-          ...apiOptions,
-          json: false,
-          body: form,
-        });
-        const {url, alt} = JSON.parse(body);
-
-        assetsList.push({label, alt, url});
-
-        logger.log('Uploaded file: %s', url);
+      urlAssets.map(async asset => {
+        await links(repoId, gitTag, asset);
+        logger.log('Added link to asset %s (%s)', asset.url, asset.name);
       })
     );
   }
 
-  debug('Update git tag %o with commit %o and release description', gitTag, gitHead);
-  await got.post(urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/repository/tags/${encodedGitTag}/release`), {
-    ...apiOptions,
-    body: {tag_name: gitTag, description: notes}, // eslint-disable-line camelcase
-  });
-
-  if (assetsList.length > 0) {
+  // Upload and add all file assets declaring a `path` property (globbed paths are expanded)
+  if (!isEmpty(fileAssets)) {
     await Promise.all(
-      assetsList.map(({label, alt, url}) => {
-        debug('Add link to asset %o', label || alt);
-        return got.post(urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/releases/${encodedGitTag}/assets/links`), {
-          ...apiOptions,
-          body: {name: label || alt, url: urlJoin(gitlabUrl, repoId, url)},
-        });
+      fileAssets.map(async ({file, label}) => {
+        // Uploaded assets to the project
+        const form = new FormData();
+        form.append('file', createReadStream(file));
+
+        const {url, alt} = await uploads(repoId, form);
+        logger.log('Uploaded file: %s', url);
+
+        await links(repoId, gitTag, {name: label || alt, url: urlJoin(gitlabUrl, repoId, url)});
+        debug('Added link to asset %o', url);
       })
     );
   }
 
   logger.log('Published GitLab release: %s', gitTag);
 
-  return {url: urlJoin(gitlabUrl, encodedRepoId, `/tags/${encodedGitTag}`), name: 'GitLab release'};
-};
+  return {url: tagUrl(gitlabUrl, repoId, gitTag), name: 'GitLab release'};
+}
+
+module.exports = publish;

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -13,7 +13,9 @@ const isArrayOf = validator => array => isArray(array) && array.every(value => v
 
 const VALIDATORS = {
   assets: isArrayOf(
-    asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path))
+    asset =>
+      isStringOrStringArray(asset) ||
+      (isPlainObject(asset) && (isStringOrStringArray(asset.path) || isNonEmptyString(asset.url)))
   ),
 };
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "prettier": {
     "printWidth": 120,
+    "singleQuote": true,
     "trailingComma": "es5"
   },
   "publishConfig": {


### PR DESCRIPTION
Allow `assets` to declare `{ url, name }` objects in order to produce links to external resources as an alternative to uploading files. Both `url` and `name` (and its alias, `label`) support templating through [`lodash.template`](https://lodash.com/docs/4.17.15#template) using a `{{}}` delimiter.

```json
{
  "plugins": [
    "@semantic-release/commit-analyzer",
    "@semantic-release/release-notes-generator",
    ["@semantic-release/gitlab", {
      "gitlabUrl": "https://custom.gitlab.com",
      "assets": [
        {"path": "dist/asset.min.css", "label": "CSS distribution"},
        {"url": "https://s3.amazonaws.com/{{env.ASSETS_BUCKET}}", "label": "asset@{{nextRelease.version}}"},
      ]
    }]
  ]
}
```

This will help ease off situations where the artifact/s produced by a build are already uploaded to some other repository elsewhere in the pipeline (see https://github.com/semantic-release/gitlab/issues/65).
