### PR TITLE
fix(resolve-config.js): use the env CI_JOB_TOKEN for the gitlab token

### DIFF
--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -15,6 +15,7 @@ module.exports = (
       GITLAB_URL,
       GL_PREFIX,
       GITLAB_PREFIX,
+      CI_JOB_TOKEN,
     },
   }
 ) => {
@@ -31,7 +32,7 @@ module.exports = (
       : 'https://gitlab.com');
 
   return {
-    gitlabToken: GL_TOKEN || GITLAB_TOKEN,
+    gitlabToken: GL_TOKEN || GITLAB_TOKEN || CI_JOB_TOKEN,
     gitlabUrl: defaultedGitlabUrl,
     gitlabApiUrl:
       userGitlabUrl && userGitlabApiPathPrefix


### PR DESCRIPTION
This merge would resolve issue #156.

If the env `GL_TOKEN` and `GITLAB_TOKEN` are not defined the env `CI_JOB_TOKEN` would be used.

With the usage of the env `CI_JOB_TOKEN` the user who triggers the pipeline would also be the author of the new tag and release. This could cause some permission problems if the user who triggers the pipeline has not permission to create tags or/and releases.