### PR TITLE
fix(publish): use file name as label when multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Create a [personal access token](https://docs.gitlab.com/ce/user/profile/persona
 Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` of
 [globs](https://github.com/isaacs/node-glob#glob-primer) and `Object`s with the following properties:
 
-| Property | Description                                                                                              | Default                              |
-| -------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `path`   | **Required.** A [glob](https://github.com/isaacs/node-glob#glob-primer) to identify the files to upload. | -                                    |
-| `label`  | Short description of the file displayed on the GitLab release.                                           | File name extracted from the `path`. |
+| Property | Description                                                                                                 | Default                              |
+| -------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `path`   | **Required.** A [glob](https://github.com/isaacs/node-glob#glob-primer) to identify the files to upload.    | -                                    |
+| `label`  | Short description of the file displayed on the GitLab release. Ignored if `path` matches more than one file.| File name extracted from the `path`. |
 
 Each entry in the `assets` `Array` is globbed individually. A [glob](https://github.com/isaacs/node-glob#glob-primer)
 can be a `String` (`"dist/**/*.js"` or `"dist/mylib.js"`) or an `Array` of `String`s that will be globbed together

--- a/lib/glob-assets.js
+++ b/lib/glob-assets.js
@@ -38,9 +38,9 @@ module.exports = async ({cwd}, assets) =>
                 // If asset is an Object with a glob the `path` property that resolve to multiple files,
                 // Output an Object definition for each file matched and set each one with:
                 // - `path` of the matched file
-                // - `name` based on the actual file name (to avoid assets with duplicate `name`)
+                // - `label` based on the actual file name (to avoid assets with duplicate `label`s)
                 // - other properties of the original asset definition
-                return globbed.map(file => ({...asset, path: file, name: basename(file)}));
+                return globbed.map(file => ({...asset, path: file, label: basename(file)}));
               }
 
               // If asset is an Object, output an Object definition with:

--- a/test/glob-assets.test.js
+++ b/test/glob-assets.test.js
@@ -127,13 +127,13 @@ test('Accept glob array with one value for missing files', async t => {
 test('Replace name by filename for Object that match multiple files', async t => {
   const cwd = tempy.directory();
   await copy(fixtures, cwd);
-  const globbedAssets = await globAssets({cwd}, [{path: '*.txt', name: 'upload_name', label: 'Upload label'}]);
+  const globbedAssets = await globAssets({cwd}, [{path: '*.txt', label: 'Upload label'}]);
 
   t.deepEqual(
     sortAssets(globbedAssets),
     sortAssets([
-      {path: 'upload.txt', name: 'upload.txt', label: 'Upload label'},
-      {path: 'upload_other.txt', name: 'upload_other.txt', label: 'Upload label'},
+      {path: 'upload.txt', label: 'upload.txt'},
+      {path: 'upload_other.txt', label: 'upload_other.txt'},
     ])
   );
 });


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/semantic-release/gitlab/issues/158 by using the correct property name (`label`) that is used as the link name in the GitLab release.

### Screenshots

Given a configuration like this:

```json
{
  "plugins": [
    [
      "@semantic-release/gitlab",
      {
        "assets": [
          { "path": "src/**/*", "label": "Source files" },
          { "path": "build/**/*", "label": "Compiled files" }
        ]
      }
    ]
  ]
}

```

**Before:**

When a glob pattern matched multiple files (just `build/**/*` in this example), each matched file was uploaded with the provided name ("Compiled files"), causing a validation error for every file but the first. 

<img width="802" alt="before" src="https://user-images.githubusercontent.com/1638631/100131417-028e2c80-2e52-11eb-83bb-0786772108fc.png">

**After:**

When a glob pattern matches multiple files, each matched file is uploaded with its file name instead of the provided `label`.

<img width="744" alt="after" src="https://user-images.githubusercontent.com/1638631/100131433-08840d80-2e52-11eb-8bd2-943b7e4a3886.png">

---

Closes https://github.com/semantic-release/gitlab/issues/158