### PR TITLE
fix: update release URL returned from publish.js

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -88,5 +88,5 @@ module.exports = async (pluginConfig, context) => {
 
   logger.log('Published GitLab release: %s', gitTag);
 
-  return {url: urlJoin(gitlabUrl, encodedRepoId, `/tags/${encodedGitTag}`), name: 'GitLab release'};
+  return {url: urlJoin(gitlabUrl, encodedRepoId, `/-/releases/${encodedGitTag}`), name: 'GitLab release'};
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -76,7 +76,7 @@ test.serial('Publish a release', async t => {
 
   const result = await t.context.m.publish({}, {env, nextRelease, options, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${nextRelease.gitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${nextRelease.gitTag}`);
   t.deepEqual(t.context.log.args[0], ['Verify GitLab authentication (%s)', 'https://gitlab.com/api/v4']);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
@@ -105,7 +105,7 @@ test.serial('Verify Github auth and release', async t => {
   await t.notThrowsAsync(t.context.m.verifyConditions({}, {env, options, logger: t.context.logger}));
   const result = await t.context.m.publish({}, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${nextRelease.gitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${nextRelease.gitTag}`);
   t.deepEqual(t.context.log.args[0], ['Verify GitLab authentication (%s)', 'https://gitlab.com/api/v4']);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -40,7 +40,7 @@ test.serial('Publish a release', async t => {
 
   const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
@@ -76,7 +76,7 @@ test.serial('Publish a release with assets', async t => {
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
@@ -105,7 +105,7 @@ test.serial('Publish a release with array of missing assets', async t => {
     .reply(200);
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
@@ -142,7 +142,7 @@ test.serial('Publish a release with one asset and custom label', async t => {
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
@@ -170,7 +170,7 @@ test.serial('Publish a release with missing release notes', async t => {
 
   const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/tags/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });


### PR DESCRIPTION
### Context

I noticed this while putting together https://github.com/semantic-release/gitlab/pull/184 and thought I'd open a separate issue to discuss.

### What does this PR do?

Updates the return value of `publish.js` to return a web URL to the _release_ instead of the _tag_. This is more consistent with `semantic-release/github`: https://github.com/semantic-release/github/blob/81847f1abd1c9714e28a17f712739ffebb586bec/lib/publish.js#L101

Here's an example of what a "tag" page looks like: https://gitlab.com/gitlab-org/gitlab/-/tags/v13.6.0-ee

And here's an example of its corresponding "release" page: https://gitlab.com/gitlab-org/gitlab/-/releases/v13.6.0-ee

The later is a nicer representation of the release, and we may be removing release notes from the former in the future: https://gitlab.com/gitlab-org/gitlab/-/issues/292279.

### Question

I looked through the plugin authoring docs, but I wasn't able to find how this return value is actually used. As a result, I'm not exactly sure what kind of change this is (`fix`, `feat`, or maybe even `BREAKING CHANGE`?).