### PR TITLE
fix: handle errors that don't have a `response`

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -59,9 +59,9 @@ module.exports = async (pluginConfig, context) => {
         errors.push(getError('EGLNOPERMISSION', {repoId}));
       }
     } catch (error) {
-      if (error.response.statusCode === 401) {
+      if (error.response && error.response.statusCode === 401) {
         errors.push(getError('EINVALIDGLTOKEN', {repoId}));
-      } else if (error.response.statusCode === 404) {
+      } else if (error.response && error.response.statusCode === 404) {
         errors.push(getError('EMISSINGREPO', {repoId}));
       } else {
         throw error;


### PR DESCRIPTION
### What does this PR do?

Currently, the error handling in `verify.js` assumes the error object will always contain a `response` property. This isn't always true; for example, SSL errors will throw an error object without a `response`.

This MR updates the error handling to check for `response` before accessing `response.statusCode`. If `response` doesn't exist, the error is re-thrown.

Related to https://github.com/semantic-release/gitlab/issues/186 and https://github.com/semantic-release/gitlab/issues/212