### PR TITLE
feat: support gitlab milestones in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ Create a [personal access token](https://docs.gitlab.com/ce/user/profile/persona
 
 ### Options
 
-| Option                | Description                                                        | Default                                                                                                                                                                 |
-|-----------------------|--------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gitlabUrl`           | The GitLab endpoint.                                               | `GL_URL` or `GITLAB_URL` environment variable or CI provided environment variables if running on [GitLab CI/CD](https://docs.gitlab.com/ee/ci) or `https://gitlab.com`. |
-| `gitlabApiPathPrefix` | The GitLab API prefix.                                             | `GL_PREFIX` or `GITLAB_PREFIX` environment variable or CI provided environment variables if running on [GitLab CI/CD](https://docs.gitlab.com/ee/ci) or `/api/v4`.      |
-| `assets`              | An array of files to upload to the release. See [assets](#assets). | -                                                                                                                                                                       |
+| Option                | Description                                                                                                                                    | Default                                                                                                                                                                 |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gitlabUrl`           | The GitLab endpoint.                                                                                                                           | `GL_URL` or `GITLAB_URL` environment variable or CI provided environment variables if running on [GitLab CI/CD](https://docs.gitlab.com/ee/ci) or `https://gitlab.com`. |
+| `gitlabApiPathPrefix` | The GitLab API prefix.                                                                                                                         | `GL_PREFIX` or `GITLAB_PREFIX` environment variable or CI provided environment variables if running on [GitLab CI/CD](https://docs.gitlab.com/ee/ci) or `/api/v4`.      |
+| `assets`              | An array of files to upload to the release. See [assets](#assets).                                                                             | -                                                                                                                                                                       |
+| `milestones`          | An array of milestone titles to associate to the release. See [GitLab Release API](https://docs.gitlab.com/ee/api/releases/#create-a-release). | -                                                                                                                                                                       |
 
 #### assets
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -17,7 +17,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease: {gitTag, gitHead, notes},
     logger,
   } = context;
-  const {gitlabToken, gitlabUrl, gitlabApiUrl, assets} = resolveConfig(pluginConfig, context);
+  const {gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones} = resolveConfig(pluginConfig, context);
   const assetsList = [];
   const repoId = getRepoId(context, gitlabUrl, repositoryUrl);
   const encodedRepoId = encodeURIComponent(repoId);
@@ -27,6 +27,7 @@ module.exports = async (pluginConfig, context) => {
   debug('repoId: %o', repoId);
   debug('release name: %o', gitTag);
   debug('release ref: %o', gitHead);
+  debug('milestones: %o', milestones);
 
   if (assets && assets.length > 0) {
     const globbedAssets = await getAssets(context, assets);
@@ -74,6 +75,7 @@ module.exports = async (pluginConfig, context) => {
       /* eslint-disable camelcase */
       tag_name: gitTag,
       description: notes && notes.trim() ? notes : gitTag,
+      milestones,
       assets: {
         links: assetsList.map(({label, alt, url}) => {
           return {

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -2,7 +2,7 @@ const {castArray, isNil} = require('lodash');
 const urlJoin = require('url-join');
 
 module.exports = (
-  {gitlabUrl, gitlabApiPathPrefix, assets},
+  {gitlabUrl, gitlabApiPathPrefix, assets, milestones},
   {
     envCi: {service} = {},
     env: {
@@ -40,5 +40,6 @@ module.exports = (
         ? CI_API_V4_URL
         : urlJoin(defaultedGitlabUrl, isNil(userGitlabApiPathPrefix) ? '/api/v4' : userGitlabApiPathPrefix),
     assets: assets ? castArray(assets) : assets,
+    milestones: milestones ? castArray(milestones) : milestones,
   };
 };

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -83,6 +83,33 @@ test.serial('Publish a release with assets', async t => {
   t.true(gitlab.isDone());
 });
 
+test.serial('Publish a release with a milestone', async t => {
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const env = {GITLAB_TOKEN: 'gitlab_token'};
+  const pluginConfig = {milestones: ['1.2.3']};
+  const nextRelease = {gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body'};
+  const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
+  const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedRepoId}/releases`, {
+      tag_name: nextRelease.gitTag,
+      description: nextRelease.notes,
+      assets: {
+        links: [],
+      },
+      milestones: ['1.2.3'],
+    })
+    .reply(200);
+
+  const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
+
+  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
+  t.true(gitlab.isDone());
+});
+
 test.serial('Publish a release with array of missing assets', async t => {
   const cwd = 'test/fixtures/files';
   const owner = 'test_user';

--- a/test/resolve-config.test.js
+++ b/test/resolve-config.test.js
@@ -13,6 +13,7 @@ test('Returns user config', t => {
     gitlabUrl,
     gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
     assets,
+    milestones: undefined,
   });
 });
 
@@ -21,13 +22,20 @@ test('Returns user config via environment variables', t => {
   const gitlabUrl = 'https://host.com';
   const gitlabApiPathPrefix = '/api/prefix';
   const assets = ['file.js'];
+  const milestones = ['1.2.3'];
 
   t.deepEqual(
     resolveConfig(
-      {assets},
+      {assets, milestones},
       {env: {GITLAB_TOKEN: gitlabToken, GITLAB_URL: gitlabUrl, GITLAB_PREFIX: gitlabApiPathPrefix}}
     ),
-    {gitlabToken, gitlabUrl, gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix), assets}
+    {
+      gitlabToken,
+      gitlabUrl,
+      gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
+      assets,
+      milestones,
+    }
   );
 });
 
@@ -39,7 +47,13 @@ test('Returns user config via alternative environment variables', t => {
 
   t.deepEqual(
     resolveConfig({assets}, {env: {GL_TOKEN: gitlabToken, GL_URL: gitlabUrl, GL_PREFIX: gitlabApiPathPrefix}}),
-    {gitlabToken, gitlabUrl, gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix), assets}
+    {
+      gitlabToken,
+      gitlabUrl,
+      gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
+      assets,
+      milestones: undefined,
+    }
   );
 });
 
@@ -53,6 +67,7 @@ test('Returns default config', t => {
     gitlabUrl: 'https://gitlab.com',
     gitlabApiUrl: urlJoin('https://gitlab.com', '/api/v4'),
     assets: undefined,
+    milestones: undefined,
   });
 
   t.deepEqual(resolveConfig({gitlabApiPathPrefix}, {env: {GL_TOKEN: gitlabToken}}), {
@@ -60,6 +75,7 @@ test('Returns default config', t => {
     gitlabUrl: 'https://gitlab.com',
     gitlabApiUrl: urlJoin('https://gitlab.com', gitlabApiPathPrefix),
     assets: undefined,
+    milestones: undefined,
   });
 
   t.deepEqual(resolveConfig({gitlabUrl}, {env: {GL_TOKEN: gitlabToken}}), {
@@ -67,6 +83,7 @@ test('Returns default config', t => {
     gitlabUrl: 'https://gitlab.com',
     gitlabApiUrl: urlJoin(gitlabUrl, '/api/v4'),
     assets: undefined,
+    milestones: undefined,
   });
 });
 
@@ -84,7 +101,13 @@ test('Returns default config via GitLab CI/CD environment variables', t => {
         env: {GL_TOKEN: gitlabToken, CI_PROJECT_URL, CI_PROJECT_PATH, CI_API_V4_URL},
       }
     ),
-    {gitlabToken, gitlabUrl: 'http://ci-host.com', gitlabApiUrl: CI_API_V4_URL, assets: undefined}
+    {
+      gitlabToken,
+      gitlabUrl: 'http://ci-host.com',
+      gitlabApiUrl: CI_API_V4_URL,
+      assets: undefined,
+      milestones: undefined,
+    }
   );
 });
 
@@ -105,7 +128,13 @@ test('Returns user config over GitLab CI/CD environment variables', t => {
         env: {GL_TOKEN: gitlabToken, CI_PROJECT_URL, CI_PROJECT_PATH, CI_API_V4_URL},
       }
     ),
-    {gitlabToken, gitlabUrl, gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix), assets}
+    {
+      gitlabToken,
+      gitlabUrl,
+      gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
+      assets,
+      milestones: undefined,
+    }
   );
 });
 
@@ -132,7 +161,13 @@ test('Returns user config via environment variables over GitLab CI/CD environmen
         },
       }
     ),
-    {gitlabToken, gitlabUrl, gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix), assets: undefined}
+    {
+      gitlabToken,
+      gitlabUrl,
+      gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
+      assets: undefined,
+      milestones: undefined,
+    }
   );
 });
 
@@ -159,7 +194,13 @@ test('Returns user config via alternative environment variables over GitLab CI/C
         },
       }
     ),
-    {gitlabToken, gitlabUrl, gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix), assets: undefined}
+    {
+      gitlabToken,
+      gitlabUrl,
+      gitlabApiUrl: urlJoin(gitlabUrl, gitlabApiPathPrefix),
+      assets: undefined,
+      milestones: undefined,
+    }
   );
 });
 
@@ -182,6 +223,7 @@ test('Ignore GitLab CI/CD environment variables if not running on GitLab CI/CD',
       gitlabUrl: 'https://gitlab.com',
       gitlabApiUrl: urlJoin('https://gitlab.com', '/api/v4'),
       assets: undefined,
+      milestones: undefined,
     }
   );
 });


### PR DESCRIPTION
Adds support to attach milestones to the created GitLab Release via the plugin configuration

See: https://docs.gitlab.com/ee/api/releases/#create-a-release