### PR TITLE
fix: better error logging for network errors

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -59,9 +59,20 @@ module.exports = async (pluginConfig, context) => {
         // Uploaded assets to the project
         const form = new FormData();
         form.append('file', createReadStream(file));
-        const {url, alt} = await got
-          .post(urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/uploads`), {...apiOptions, body: form})
-          .json();
+
+        const uploadEndpoint = urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/uploads`);
+
+        debug('POST-ing the file %s to %s', file, uploadEndpoint);
+
+        let response;
+        try {
+          response = await got.post(uploadEndpoint, {...apiOptions, body: form}).json();
+        } catch (error) {
+          logger.error('An error occurred while uploading %s to the GitLab project uploads API:\n%O', file, error);
+          throw error;
+        }
+
+        const {url, alt} = response;
 
         assetsList.push({label, alt, url, type, filepath});
 
@@ -71,26 +82,38 @@ module.exports = async (pluginConfig, context) => {
   }
 
   debug('Create a release for git tag %o with commit %o', gitTag, gitHead);
-  await got.post(urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/releases`), {
-    ...apiOptions,
-    json: {
-      /* eslint-disable camelcase */
-      tag_name: gitTag,
-      description: notes && notes.trim() ? notes : gitTag,
-      milestones,
-      assets: {
-        links: assetsList.map(({label, alt, url, type, filepath}) => {
-          return {
-            name: label || alt,
-            url: urlJoin(gitlabUrl, repoId, url),
-            link_type: type,
-            filepath,
-          };
-        }),
-      },
-      /* eslint-enable camelcase */
+
+  const createReleaseEndpoint = urlJoin(gitlabApiUrl, `/projects/${encodedRepoId}/releases`);
+
+  const json = {
+    /* eslint-disable camelcase */
+    tag_name: gitTag,
+    description: notes && notes.trim() ? notes : gitTag,
+    milestones,
+    assets: {
+      links: assetsList.map(({label, alt, url, type, filepath}) => {
+        return {
+          name: label || alt,
+          url: urlJoin(gitlabUrl, repoId, url),
+          link_type: type,
+          filepath,
+        };
+      }),
     },
-  });
+    /* eslint-enable camelcase */
+  };
+
+  debug('POST-ing the following JSON to %s:\n%s', createReleaseEndpoint, JSON.stringify(json, null, 2));
+
+  try {
+    await got.post(createReleaseEndpoint, {
+      ...apiOptions,
+      json,
+    });
+  } catch (error) {
+    logger.error('An error occurred while making a request to the GitLab release API:\n%O', error);
+    throw error;
+  }
 
   logger.log('Published GitLab release: %s', gitTag);
 


### PR DESCRIPTION
### What does this PR do?

Adds some additional logging to `publish.js`, including error logs when requests to GitLab's API fail.

### Why?

Currently, if a request to GitLab's API fails, this plugin logs a generic error message without any specifics. This makes it hard for end-users to diagnose and fix issues.