### PR TITLE
fix: display default icons and fix URL in success message

### DIFF
--- a/lib/get-success-comment.js
+++ b/lib/get-success-comment.js
@@ -14,4 +14,4 @@ module.exports = (issueOrMergeRequest, releaseInfos, nextRelease) =>
         }`
       : ''
   }
-Your **[semantic-release](${HOME_URL})** bot :package::rocket:`;
+Your **[semantic-release](${HOME_URL})** bot :package: :rocket:`;

--- a/lib/get-success-comment.js
+++ b/lib/get-success-comment.js
@@ -7,11 +7,11 @@ module.exports = (issueOrMergeRequest, releaseInfos, nextRelease) =>
     nextRelease.version
   } :tada:${
     releaseInfos.length > 0
-      ? `\n\nThe release is available on${decodeURIComponent(
+      ? `\n\nThe release is available on${
           releaseInfos.length === 1
             ? ` ${linkify(releaseInfos[0])}`
             : `:\n${releaseInfos.map(releaseInfo => `- ${linkify(releaseInfo)}`).join('\n')}`
-        )}`
+        }`
       : ''
   }
 Your **[semantic-release](${HOME_URL})** bot :package: :rocket:`;

--- a/lib/get-success-comment.js
+++ b/lib/get-success-comment.js
@@ -7,11 +7,11 @@ module.exports = (issueOrMergeRequest, releaseInfos, nextRelease) =>
     nextRelease.version
   } :tada:${
     releaseInfos.length > 0
-      ? `\n\nThe release is available on${
+      ? `\n\nThe release is available on${decodeURIComponent(
           releaseInfos.length === 1
             ? ` ${linkify(releaseInfos[0])}`
             : `:\n${releaseInfos.map(releaseInfo => `- ${linkify(releaseInfo)}`).join('\n')}`
-        }`
+        )}`
       : ''
   }
 Your **[semantic-release](${HOME_URL})** bot :package: :rocket:`;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -118,7 +118,7 @@ module.exports = async (pluginConfig, context) => {
 
   logger.log('Published GitLab release: %s', gitTag);
 
-  const releaseUrl = urlJoin(gitlabUrl, encodedRepoId, `/-/releases/${encodedGitTag}`);
+  const releaseUrl = decodeURIComponent(urlJoin(gitlabUrl, encodedRepoId, `/-/releases/${encodedGitTag}`));
 
   return {name: RELEASE_NAME, url: releaseUrl};
 };

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -118,7 +118,7 @@ module.exports = async (pluginConfig, context) => {
 
   logger.log('Published GitLab release: %s', gitTag);
 
-  const releaseUrl = decodeURIComponent(urlJoin(gitlabUrl, encodedRepoId, `/-/releases/${encodedGitTag}`));
+  const releaseUrl = urlJoin(gitlabUrl, repoId, `/-/releases/${encodedGitTag}`);
 
   return {name: RELEASE_NAME, url: releaseUrl};
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -76,7 +76,7 @@ test.serial('Publish a release', async t => {
 
   const result = await t.context.m.publish({}, {env, nextRelease, options, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${nextRelease.gitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${nextRelease.gitTag}`);
   t.deepEqual(t.context.log.args[0], ['Verify GitLab authentication (%s)', 'https://gitlab.com/api/v4']);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
@@ -105,7 +105,7 @@ test.serial('Verify Github auth and release', async t => {
   await t.notThrowsAsync(t.context.m.verifyConditions({}, {env, options, logger: t.context.logger}));
   const result = await t.context.m.publish({}, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${nextRelease.gitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${nextRelease.gitTag}`);
   t.deepEqual(t.context.log.args[0], ['Verify GitLab authentication (%s)', 'https://gitlab.com/api/v4']);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -40,7 +40,7 @@ test.serial('Publish a release', async t => {
 
   const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
@@ -76,7 +76,7 @@ test.serial('Publish a release with assets', async t => {
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
@@ -122,7 +122,7 @@ test.serial('Publish a release with asset type and permalink', async t => {
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
@@ -151,7 +151,7 @@ test.serial('Publish a release with a milestone', async t => {
 
   const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
@@ -178,7 +178,7 @@ test.serial('Publish a release with array of missing assets', async t => {
     .reply(200);
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
@@ -215,7 +215,7 @@ test.serial('Publish a release with one asset and custom label', async t => {
 
   const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
   t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlabUpload.isDone());
@@ -243,7 +243,7 @@ test.serial('Publish a release with missing release notes', async t => {
 
   const result = await publish(pluginConfig, {env, options, nextRelease, logger: t.context.logger});
 
-  t.is(result.url, `https://gitlab.com/${encodedRepoId}/-/releases/${encodedGitTag}`);
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
   t.deepEqual(t.context.log.args[0], ['Published GitLab release: %s', nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -25,7 +25,7 @@ test.serial('Post comments to related issues and MRs', async t => {
   const env = {GITLAB_TOKEN: 'gitlab_token'};
   const pluginConfig = {};
   const nextRelease = {version: '1.0.0'};
-  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0'}];
+  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user/test_repo/-/releases/v1.0.0'}];
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
   const commits = [{hash: 'abcdef'}, {hash: 'fedcba'}];
@@ -48,14 +48,14 @@ test.serial('Post comments to related issues and MRs', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/300/merge_requests/3/notes`)
     .reply(200)
     .post(`/projects/100/issues/11/notes`, {
       body:
-        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/100/issues/13/notes`)
@@ -74,7 +74,7 @@ test.serial('Post comments with custom template', async t => {
     successComment: `nextRelease: \${nextRelease.version} commits: \${commits.length} releases: \${releases.length} \${issue ? "issue" : "MR"} ID: \${issue ? issue.iid : mergeRequest.iid}`,
   };
   const nextRelease = {version: '1.0.0'};
-  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0'}];
+  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user/test_repo/-/releases/v1.0.0'}];
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
   const commits = [{hash: 'abcdef'}];
@@ -104,7 +104,7 @@ test.serial('Post comments for multiple releases', async t => {
   const pluginConfig = {};
   const nextRelease = {version: '1.0.0'};
   const releases = [
-    {name: RELEASE_NAME, url: 'https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0'},
+    {name: RELEASE_NAME, url: 'https://gitlab.com/test_user/test_repo/-/releases/v1.0.0'},
     {name: 'Other release'},
   ];
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
@@ -117,7 +117,7 @@ test.serial('Post comments for multiple releases', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200);
 
@@ -132,7 +132,7 @@ test.serial('Does not post comments when successComment is set to false', async 
   const repo = 'test_repo';
   const env = {GITLAB_TOKEN: 'gitlab_token'};
   const nextRelease = {version: '1.0.0'};
-  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0'}];
+  const releases = [{name: RELEASE_NAME, url: 'https://gitlab.com/test_user/test_repo/-/releases/v1.0.0'}];
   const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
   const commits = [{hash: 'abcdef'}, {hash: 'fedcba'}];
   const gitlab = authenticate(env);

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -48,14 +48,14 @@ test.serial('Post comments to related issues and MRs', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/300/merge_requests/3/notes`)
     .reply(200)
     .post(`/projects/100/issues/11/notes`, {
       body:
-        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:',
+        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/100/issues/13/notes`)
@@ -117,7 +117,7 @@ test.serial('Post comments for multiple releases', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200);
 

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -48,14 +48,14 @@ test.serial('Post comments to related issues and MRs', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/300/merge_requests/3/notes`)
     .reply(200)
     .post(`/projects/100/issues/11/notes`, {
       body:
-        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This issue has been resolved in version 1.0.0 :tada:\n\nThe release is available on [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200)
     .post(`/projects/100/issues/13/notes`)
@@ -117,7 +117,7 @@ test.serial('Post comments for multiple releases', async t => {
     .reply(200, [])
     .post(`/projects/100/merge_requests/1/notes`, {
       body:
-        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user/test_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
+        ':tada: This MR is included in version 1.0.0 :tada:\n\nThe release is available on:\n- [GitLab release](https://gitlab.com/test_user%2Ftest_repo/-/releases/v1.0.0)\n- `Other release`\nYour **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package: :rocket:',
     })
     .reply(200);
 


### PR DESCRIPTION
First of all thanks to @fgreinacher for this nice feature.
We are using it already and I stumpled upon two issues:
- the :package: and :rocket: icon were not proberly displayed as they were not separated
- the URL to the release did not work because of `%2F` in the URI; this is why I added the `decodeURIComponent`

Fixes #344 