### PR TITLE
feat: add support for NO_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create a [personal access token](https://docs.gitlab.com/ce/user/profile/persona
 | `GL_URL` or `GITLAB_URL`       | The GitLab endpoint.                                      |
 | `GL_PREFIX` or `GITLAB_PREFIX` | The GitLab API prefix.                                    |
 | `HTTP_PROXY` or `HTTPS_PROXY`  | HTTP or HTTPS proxy to use.                               |
-| `NO_PROXY`                     | NO_PROXY bypass proxy hosts                               |
+| `NO_PROXY`                     | Patterns for which the proxy should be ignored. See [details below](#proxy-configuration). |
 
 #### Proxy configuration
 
@@ -69,11 +69,7 @@ If your proxy server requires authentication embed the username and password in 
 
 If your GitLab instance is exposed via plain HTTP (not recommended!) use `HTTP_PROXY` instead.
 
-#### Proxy bypass configuration
-
-You can configure a bypass option by setting `NO_PROXY` environment variable: `NO_PROXY=*.host.com, host.com`
-
-Depending on your gitlabUrl and a matching `NO_PROXY`it is bypassing your proxy configuration of the `HTTP_PROXY` or `HTTPS_PROXY` environment variable.
+If you need to bypass the proxy for some hosts, configure the `NO_PROXY` environment variable: NO_PROXY=*.host.com, host.com`
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If your proxy server requires authentication embed the username and password in 
 
 If your GitLab instance is exposed via plain HTTP (not recommended!) use `HTTP_PROXY` instead.
 
-If you need to bypass the proxy for some hosts, configure the `NO_PROXY` environment variable: NO_PROXY=*.host.com, host.com`
+If you need to bypass the proxy for some hosts, configure the `NO_PROXY` environment variable: `NO_PROXY=*.host.com, host.com`
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Create a [personal access token](https://docs.gitlab.com/ce/user/profile/persona
 | `GL_URL` or `GITLAB_URL`       | The GitLab endpoint.                                      |
 | `GL_PREFIX` or `GITLAB_PREFIX` | The GitLab API prefix.                                    |
 | `HTTP_PROXY` or `HTTPS_PROXY`  | HTTP or HTTPS proxy to use.                               |
+| `NO_PROXY`                     | NO_PROXY bypass proxy hosts                               |
 
 #### Proxy configuration
 
@@ -67,6 +68,12 @@ You can configure a proxy server via the `HTTPS_PROXY` environment variable: `HT
 If your proxy server requires authentication embed the username and password in the URL: `HTTPS_PROXY=http://user:pwd@proxyurl.com:8080`
 
 If your GitLab instance is exposed via plain HTTP (not recommended!) use `HTTP_PROXY` instead.
+
+#### Proxy bypass configuration
+
+You can configure a bypass option by setting `NO_PROXY` environment variable: `NO_PROXY=*.host.com, host.com`
+
+Depending on your gitlabUrl and a matching `NO_PROXY`it is bypassing your proxy configuration of the `HTTP_PROXY` or `HTTPS_PROXY` environment variable.
 
 ### Options
 

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -49,6 +49,7 @@ module.exports = (
   };
 };
 
+// Copied from Rob Wu's great proxy-from-env library: https://github.com/Rob--W/proxy-from-env/blob/96d01f8fcfdccfb776735751132930bbf79c4a3a/index.js#L62
 function shouldProxy(gitlabUrl, NO_PROXY) {
   const DEFAULT_PORTS = {
     ftp: 21,

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -18,7 +18,7 @@ module.exports = (
       GITLAB_PREFIX,
       HTTP_PROXY,
       HTTPS_PROXY,
-      NO_PROXY
+      NO_PROXY,
     },
   }
 ) => {
@@ -95,6 +95,3 @@ function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY) {
 
   return {};
 }
-© 2022 GitHub, Inc.
-Terms
-Privacy

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,6 +1,7 @@
 const {castArray, isNil} = require('lodash');
 const urlJoin = require('url-join');
 const {HttpProxyAgent, HttpsProxyAgent} = require('hpagent');
+const {getProxyForUrl} = require('proxy-from-env');
 
 module.exports = (
   {gitlabUrl, gitlabApiPathPrefix, assets, milestones, successComment},
@@ -16,9 +17,6 @@ module.exports = (
       GITLAB_URL,
       GL_PREFIX,
       GITLAB_PREFIX,
-      HTTP_PROXY,
-      HTTPS_PROXY,
-      NO_PROXY,
     },
   }
 ) => {
@@ -45,21 +43,11 @@ module.exports = (
     assets: assets ? castArray(assets) : assets,
     milestones: milestones ? castArray(milestones) : milestones,
     successComment,
-    proxy: getProxyConfiguration(defaultedGitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY),
+    proxy: getProxyConfiguration(defaultedGitlabUrl),
   };
 };
- 
-function bypassProxy(NO_PROXY, gitlabUrl) {
-  if (NO_PROXY === '*') {
-    return true;
-  }
-  const hostName = gitlabUrl.split('://')[1].split(':')[0];
-  const noProxyEntries = NO_PROXY.split(',');
-  return noProxyEntries.some((proxyConfig) => {
-    return hostName.endsWith(proxyConfig.toLowerCase().trim().replace(/^\./, ""));
-  });
-}
-function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY) {
+
+function getProxyConfiguration(gitlabUrl) {
   const sharedParameters = {
     keepAlive: true,
     keepAliveMsecs: 1000,
@@ -67,30 +55,29 @@ function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY) {
     maxFreeSockets: 256,
     scheduling: 'lifo',
   };
-  if(bypassProxy(NO_PROXY, gitlabUrl)) {
-    return {};
-  }
+  const proxy = getProxyForUrl(gitlabUrl);
+  if (proxy) {
+    if (gitlabUrl.startsWith('http://')) {
+      return {
+        agent: {
+          http: new HttpProxyAgent({
+            ...sharedParameters,
+            proxy,
+          }),
+        },
+      };
+    }
 
-  if (HTTP_PROXY && gitlabUrl.startsWith('http://')) {
-    return {
-      agent: {
-        http: new HttpProxyAgent({
-          ...sharedParameters,
-          proxy: HTTP_PROXY,
-        }),
-      },
-    };
-  }
-
-  if (HTTPS_PROXY && gitlabUrl.startsWith('https://')) {
-    return {
-      agent: {
-        https: new HttpsProxyAgent({
-          ...sharedParameters,
-          proxy: HTTPS_PROXY,
-        }),
-      },
-    };
+    if (gitlabUrl.startsWith('https://')) {
+      return {
+        agent: {
+          https: new HttpsProxyAgent({
+            ...sharedParameters,
+            proxy,
+          }),
+        },
+      };
+    }
   }
 
   return {};

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,7 +1,6 @@
 const {castArray, isNil} = require('lodash');
 const urlJoin = require('url-join');
 const {HttpProxyAgent, HttpsProxyAgent} = require('hpagent');
-const {getProxyForUrl} = require('proxy-from-env');
 
 module.exports = (
   {gitlabUrl, gitlabApiPathPrefix, assets, milestones, successComment},
@@ -17,6 +16,9 @@ module.exports = (
       GITLAB_URL,
       GL_PREFIX,
       GITLAB_PREFIX,
+      HTTP_PROXY,
+      HTTPS_PROXY,
+      NO_PROXY,
     },
   }
 ) => {
@@ -43,11 +45,69 @@ module.exports = (
     assets: assets ? castArray(assets) : assets,
     milestones: milestones ? castArray(milestones) : milestones,
     successComment,
-    proxy: getProxyConfiguration(defaultedGitlabUrl),
+    proxy: getProxyConfiguration(defaultedGitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY),
   };
 };
 
-function getProxyConfiguration(gitlabUrl) {
+function shouldProxy(gitlabUrl, NO_PROXY) {
+  const DEFAULT_PORTS = {
+    ftp: 21,
+    gopher: 70,
+    http: 80,
+    https: 443,
+    ws: 80,
+    wss: 443,
+  };
+  const parsedUrl = typeof gitlabUrl === 'string' ? new URL(gitlabUrl) : gitlabUrl || {};
+  let proto = parsedUrl.protocol;
+  let hostname = parsedUrl.host;
+  let {port} = parsedUrl;
+  if (typeof hostname !== 'string' || !hostname || typeof proto !== 'string') {
+    return ''; // Don't proxy URLs without a valid scheme or host.
+  }
+
+  proto = proto.split(':', 1)[0];
+  // Stripping ports in this way instead of using parsedUrl.hostname to make
+  // sure that the brackets around IPv6 addresses are kept.
+  hostname = hostname.replace(/:\d*$/, '');
+  port = parseInt(port, 10) || DEFAULT_PORTS[proto] || 0;
+
+  if (!NO_PROXY) {
+    return true; // Always proxy if NO_PROXY is not set.
+  }
+
+  if (NO_PROXY === '*') {
+    return false; // Never proxy if wildcard is set.
+  }
+
+  return NO_PROXY.split(/[,\s]/).every(function(proxy) {
+    if (!proxy) {
+      return true; // Skip zero-length hosts.
+    }
+
+    const parsedProxy = proxy.match(/^(.+):(\d+)$/);
+    let parsedProxyHostname = parsedProxy ? parsedProxy[1] : proxy;
+    const parsedProxyPort = parsedProxy ? parseInt(parsedProxy[2], 10) : 0;
+    if (parsedProxyPort && parsedProxyPort !== port) {
+      return true; // Skip if ports don't match.
+    }
+
+    if (!/^[.*]/.test(parsedProxyHostname)) {
+      // No wildcards, so stop proxying if there is an exact match.
+      return hostname !== parsedProxyHostname;
+    }
+
+    if (parsedProxyHostname.charAt(0) === '*') {
+      // Remove leading wildcard.
+      parsedProxyHostname = parsedProxyHostname.slice(1);
+    }
+
+    // Stop proxying if the hostname ends with the no_proxy host.
+    return !hostname.endsWith(parsedProxyHostname);
+  });
+}
+
+function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY) {
   const sharedParameters = {
     keepAlive: true,
     keepAliveMsecs: 1000,
@@ -55,25 +115,25 @@ function getProxyConfiguration(gitlabUrl) {
     maxFreeSockets: 256,
     scheduling: 'lifo',
   };
-  const proxy = getProxyForUrl(gitlabUrl);
-  if (proxy) {
-    if (gitlabUrl.startsWith('http://')) {
+
+  if (shouldProxy(gitlabUrl, NO_PROXY)) {
+    if (HTTP_PROXY && gitlabUrl.startsWith('http://')) {
       return {
         agent: {
           http: new HttpProxyAgent({
             ...sharedParameters,
-            proxy,
+            proxy: HTTP_PROXY,
           }),
         },
       };
     }
 
-    if (gitlabUrl.startsWith('https://')) {
+    if (HTTPS_PROXY && gitlabUrl.startsWith('https://')) {
       return {
         agent: {
           https: new HttpsProxyAgent({
             ...sharedParameters,
-            proxy,
+            proxy: HTTPS_PROXY,
           }),
         },
       };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -18,6 +18,7 @@ module.exports = (
       GITLAB_PREFIX,
       HTTP_PROXY,
       HTTPS_PROXY,
+      NO_PROXY
     },
   }
 ) => {
@@ -44,11 +45,21 @@ module.exports = (
     assets: assets ? castArray(assets) : assets,
     milestones: milestones ? castArray(milestones) : milestones,
     successComment,
-    proxy: getProxyConfiguration(defaultedGitlabUrl, HTTP_PROXY, HTTPS_PROXY),
+    proxy: getProxyConfiguration(defaultedGitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY),
   };
 };
-
-function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY) {
+ 
+function bypassProxy(NO_PROXY, gitlabUrl) {
+  if (NO_PROXY === '*') {
+    return true;
+  }
+  const hostName = gitlabUrl.split('://')[1].split(':')[0];
+  const noProxyEntries = NO_PROXY.split(',');
+  return noProxyEntries.some((proxyConfig) => {
+    return hostName.endsWith(proxyConfig.toLowerCase().trim().replace(/^\./, ""));
+  });
+}
+function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY, NO_PROXY) {
   const sharedParameters = {
     keepAlive: true,
     keepAliveMsecs: 1000,
@@ -56,6 +67,9 @@ function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY) {
     maxFreeSockets: 256,
     scheduling: 'lifo',
   };
+  if(bypassProxy(NO_PROXY, gitlabUrl)) {
+    return {};
+  }
 
   if (HTTP_PROXY && gitlabUrl.startsWith('http://')) {
     return {
@@ -81,3 +95,6 @@ function getProxyConfiguration(gitlabUrl, HTTP_PROXY, HTTPS_PROXY) {
 
   return {};
 }
+© 2022 GitHub, Inc.
+Terms
+Privacy

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "hpagent": "^0.1.2",
         "lodash": "^4.17.11",
         "parse-path": "^4.0.0",
-        "proxy-from-env": "^1.1.0",
         "url-join": "^4.0.0"
       },
       "devDependencies": {
@@ -11288,11 +11287,6 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -23254,11 +23248,6 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,11 @@
         "hpagent": "^0.1.2",
         "lodash": "^4.17.11",
         "parse-path": "^4.0.0",
+        "proxy-from-env": "^1.1.0",
         "url-join": "^4.0.0"
       },
       "devDependencies": {
-        "ava": "4.1.0",
+        "ava": "^4.1.0",
         "clear-module": "4.1.2",
         "nock": "13.2.4",
         "nyc": "15.1.0",
@@ -11287,6 +11288,11 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -23248,6 +23254,11 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "url-join": "^4.0.0"
       },
       "devDependencies": {
-        "ava": "^4.1.0",
+        "ava": "4.1.0",
         "clear-module": "4.1.2",
         "nock": "13.2.4",
         "nyc": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "hpagent": "^0.1.2",
     "lodash": "^4.17.11",
     "parse-path": "^4.0.0",
+    "proxy-from-env": "^1.1.0",
     "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "ava": "4.1.0",
+    "ava": "^4.1.0",
     "clear-module": "4.1.2",
     "nock": "13.2.4",
     "nyc": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "hpagent": "^0.1.2",
     "lodash": "^4.17.11",
     "parse-path": "^4.0.0",
-    "proxy-from-env": "^1.1.0",
     "url-join": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "ava": "^4.1.0",
+    "ava": "4.1.0",
     "clear-module": "4.1.2",
     "nock": "13.2.4",
     "nyc": "15.1.0",
@@ -76,7 +76,9 @@
   },
   "prettier": {
     "printWidth": 120,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "bracketSpacing": false
   },
   "publishConfig": {
     "access": "public"

--- a/test/resolve-config.test.js
+++ b/test/resolve-config.test.js
@@ -187,6 +187,105 @@ test('Returns user config via alternative environment variables with mismatching
     }
   );
 });
+test('Returns user config via environment variables with HTTP_PROXY and NO_PROXY set', t => {
+  const gitlabToken = 'TOKEN';
+  const gitlabUrl = 'https://host.com';
+  const gitlabApiPathPrefix = '/api/prefix';
+  const assets = ['file.js'];
+  // Testing with 8080 port because HttpsProxyAgent ignores 80 port with http protocol
+  const proxyUrl = 'http://proxy.test:8080';
+  const noProxy = '*.host.com, host.com'
+
+  const result = resolveConfig(
+    {assets},
+    {
+      env: {
+        GL_TOKEN: gitlabToken,
+        GL_URL: gitlabUrl,
+        GL_PREFIX: gitlabApiPathPrefix,
+        HTTP_PROXY: proxyUrl,
+        NO_PROXY: noProxy
+      },
+    }
+  );
+
+  t.assert(result.proxy === {});
+});
+
+test('Returns user config via environment variables with HTTPS_PROXY and NO_PROXY set', t => {
+  const gitlabToken = 'TOKEN';
+  const gitlabUrl = 'https://host.com';
+  const gitlabApiPathPrefix = '/api/prefix';
+  const assets = ['file.js'];
+  // Testing with 8080 port because HttpsProxyAgent ignores 80 port with http protocol
+  const proxyUrl = 'http://proxy.test:8080';
+  const noProxy = '*.host.com, host.com'
+
+  const result = resolveConfig(
+    {assets},
+    {
+      env: {
+        GL_TOKEN: gitlabToken,
+        GL_URL: gitlabUrl,
+        GL_PREFIX: gitlabApiPathPrefix,
+        HTTPS_PROXY: proxyUrl,
+        NO_PROXY: noProxy
+      },
+    }
+  );
+
+  t.assert(result.proxy === {});
+});
+
+test('Returns user config via environment variables with HTTPS_PROXY and non-matching NO_PROXY set', t => {
+  const gitlabToken = 'TOKEN';
+  const gitlabUrl = 'https://host.com';
+  const gitlabApiPathPrefix = '/api/prefix';
+  const assets = ['file.js'];
+  // Testing with 8080 port because HttpsProxyAgent ignores 80 port with http protocol
+  const proxyUrl = 'http://proxy.test:8080';
+  const noProxy = '*.differenthost.com, differenthost.com'
+
+  const result = resolveConfig(
+    {assets},
+    {
+      env: {
+        GL_TOKEN: gitlabToken,
+        GL_URL: gitlabUrl,
+        GL_PREFIX: gitlabApiPathPrefix,
+        HTTPS_PROXY: proxyUrl,
+        NO_PROXY: noProxy
+      },
+    }
+  );
+  t.assert(result.proxy.agent.https instanceof HttpsProxyAgent);
+  t.assert(result.proxy.agent.https.proxy.origin === proxyUrl);
+});
+
+test('Returns user config via environment variables with HTTP_PROXY and non-matching NO_PROXY set', t => {
+  const gitlabToken = 'TOKEN';
+  const gitlabUrl = 'https://host.com';
+  const gitlabApiPathPrefix = '/api/prefix';
+  const assets = ['file.js'];
+  // Testing with 8080 port because HttpsProxyAgent ignores 80 port with http protocol
+  const proxyUrl = 'http://proxy.test:8080';
+  const noProxy = '*.differenthost.com, differenthost.com'
+
+  const result = resolveConfig(
+    {assets},
+    {
+      env: {
+        GL_TOKEN: gitlabToken,
+        GL_URL: gitlabUrl,
+        GL_PREFIX: gitlabApiPathPrefix,
+        HTTP_PROXY: proxyUrl,
+        NO_PROXY: noProxy
+      },
+    }
+  );
+  t.assert(result.proxy.agent.http instanceof HttpProxyAgent);
+  t.assert(result.proxy.agent.http.proxy.origin === proxyUrl);
+});
 
 test('Returns default config', t => {
   const gitlabToken = 'TOKEN';


### PR DESCRIPTION
# Please check if the MR fulfills these requirements
- [x] the commit message follows conventional commits
- [x] all required tests for the changes have been added
- [x] docs have been added in readme
# What kind of change does this MR introduce?
- Add NO_PROXY environment variable support
# What is the current behavior?
- NO_PROXY environment variables is completely ignored
# What is the new behavior (if this is a feature change)?
- NO_PROXY environment variables can be used to bypass the proxy configuration via HTTPS_PROXY and/or HTTP_PROXY envrionment variables
# Does this MR introduce a breaking change?
No
# Other information
In some cases it requires a web proxy to reach resources through the internet and outside of a company network. This will work when the gitlab Instance is also accessible through the internet, but in some cases the gitlab instance is a self hosted one and is only be reachable within the same network.
In case of that you need a proxy configuration (e.g. through HTTP_PROXY and/or HTTPS_PROXY for your build process with @semantic-release/exec) it would fail to reach the gitlab instance as a combination of proxy and no_proxy is not possible at the moment.
This PR will introduce this option to allow a combination of having HTTP_PROXY/HTTPS_PROXY and NO_PROXY environment variables