### PR TITLE
feat(assets): allow label templating #334

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
       "gitlabUrl": "https://custom.gitlab.com",
       "assets": [
         {"path": "dist/asset.min.css", "label": "CSS distribution"},
-        {"path": "dist/asset.min.js", "label": "JS distribution"}
+        {"path": "dist/asset.min.js", "label": "JS distribution"},
+        {"path": "dist/asset.min.js", "label": "v${nextRelease.version}.js"}
       ]
     }],
   ]
@@ -94,7 +95,7 @@ Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` 
 | Property | Description                                                                                                 | Default                              |
 | -------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `path`   | **Required.** A [glob](https://github.com/isaacs/node-glob#glob-primer) to identify the files to upload.    | -                                    |
-| `label`  | Short description of the file displayed on the GitLab release. Ignored if `path` matches more than one file.| File name extracted from the `path`. |
+| `label`  | Short description of the file displayed on the GitLab release. Can be dynamically adjusted with the [Lodash template](https://lodash.com/docs#template). Allows same variables as [successComment](#successComment). Ignored if `path` matches more than one file.| File name extracted from the `path`. |
 | `type` | Asset type displayed on the GitLab release. Can be `runbook`, `package`, `image` and `other` (see official documents on [release assets](https://docs.gitlab.com/ee/user/project/releases/#release-assets)). | `other` |
 | `filepath` | A filepath for creating a permalink pointing to the asset (requires GitLab 12.9+, see official documents on [permanent links](https://docs.gitlab.com/ee/user/project/releases/#permanent-links-to-release-assets)). Ignored if `path` matches more than one file. | - |
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Can be a [glob](https://github.com/isaacs/node-glob#glob-primer) or and `Array` 
 | Property | Description                                                                                                 | Default                              |
 | -------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `path`   | **Required.** A [glob](https://github.com/isaacs/node-glob#glob-primer) to identify the files to upload.    | -                                    |
-| `label`  | Short description of the file displayed on the GitLab release. Can be dynamically adjusted with the [Lodash template](https://lodash.com/docs#template). Allows same variables as [successComment](#successComment). Ignored if `path` matches more than one file.| File name extracted from the `path`. |
+| `label`  | Short description of the file displayed on the GitLab release. Can be dynamically adjusted with [Lodash template](https://lodash.com/docs#template). Allows same variables as [`successComment`](#successComment). Ignored if `path` matches more than one file. | File name extracted from the `path`. |
 | `type` | Asset type displayed on the GitLab release. Can be `runbook`, `package`, `image` and `other` (see official documents on [release assets](https://docs.gitlab.com/ee/user/project/releases/#release-assets)). | `other` |
 | `filepath` | A filepath for creating a permalink pointing to the asset (requires GitLab 12.9+, see official documents on [permanent links](https://docs.gitlab.com/ee/user/project/releases/#permanent-links-to-release-assets)). Ignored if `path` matches more than one file. | - |
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,7 +1,7 @@
 const {createReadStream} = require('fs');
 const {resolve} = require('path');
 const {stat} = require('fs-extra');
-const {isPlainObject} = require('lodash');
+const {isPlainObject, template} = require('lodash');
 const FormData = require('form-data');
 const urlJoin = require('url-join');
 const got = require('got');
@@ -36,8 +36,9 @@ module.exports = async (pluginConfig, context) => {
 
     await Promise.all(
       globbedAssets.map(async asset => {
-        const {path, label, type, filepath} = isPlainObject(asset) ? asset : {path: asset};
+        const {path, type, filepath} = isPlainObject(asset) ? asset : {path: asset};
         const file = resolve(cwd, path);
+        const label = asset.label ? template(asset.label)(context) : undefined;
         let fileStat;
 
         try {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -129,6 +129,53 @@ test.serial('Publish a release with asset type and permalink', async t => {
   t.true(gitlab.isDone());
 });
 
+test.serial('Publish a release with an asset with a template label', async t => {
+  const cwd = 'test/fixtures/files';
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const env = {GITLAB_TOKEN: 'gitlab_token'};
+  const nextRelease = {gitHead: '123', gitTag: 'v1.0.0', notes: 'Test release note body', version: '1.0.0'};
+  const options = {repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`};
+  const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const uploaded = {url: '/uploads/file.css', alt: 'file.css'};
+  const assets = [
+    {
+      label: `file-v\${nextRelease.version}.css`,
+      path: 'file.css',
+      type: 'other',
+      filepath: '/dist/file.css',
+    },
+  ];
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedRepoId}/releases`, {
+      tag_name: nextRelease.gitTag,
+      description: nextRelease.notes,
+      assets: {
+        links: [
+          {
+            name: 'file-v1.0.0.css',
+            url: `https://gitlab.com/${owner}/${repo}${uploaded.url}`,
+            link_type: 'other',
+            filepath: '/dist/file.css',
+          },
+        ],
+      },
+    })
+    .reply(200);
+  const gitlabUpload = authenticate(env)
+    .post(`/projects/${encodedRepoId}/uploads`, /filename="file.css"/gm)
+    .reply(200, uploaded);
+
+  const result = await publish({assets}, {env, cwd, options, nextRelease, logger: t.context.logger});
+
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
+  t.deepEqual(t.context.log.args[0], ['Uploaded file: %s', uploaded.url]);
+  t.deepEqual(t.context.log.args[1], ['Published GitLab release: %s', nextRelease.gitTag]);
+  t.true(gitlabUpload.isDone());
+  t.true(gitlab.isDone());
+});
+
 test.serial('Publish a release with a milestone', async t => {
   const owner = 'test_user';
   const repo = 'test_repo';


### PR DESCRIPTION
As mentioned in #334 it could be useful to use templating for the asset labels. This PR provides the functionality to use the lodash templating functionality similar to the `successComment` and the `failComment`.

Resolves #334