### PR TITLE
docs(usage): add branches to provide working example #258

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 
 ```json
 {
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
As highlighted in #258 the documentation for the usage might be a bit confusing. Without branches the configuration would not be valid. In my opinion we should provide a working example.