### PR TITLE
feat(publish): add option to skip publishing releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you need to bypass the proxy for some hosts, configure the `NO_PROXY` environ
 | `failTitle`           | The title of the issue created when a release fails. Set to `false` to disable opening an issue when a release fails.                                           | `The automated release is failing 🚨`                                                                                                                                    |
 | `labels`              | The [labels](https://docs.gitlab.com/ee/user/project/labels.html#labels) to add to the issue created when a release fails. Set to `false` to not add any label. Labels should be comma-separated as described in the [official docs](https://docs.gitlab.com/ee/api/issues.html#new-issue), e.g. `"semantic-release,bot"`. | `semantic-release`                                                                                                                                                      |
 | `assignee`            | The [assignee](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#assignee) to add to the issue created when a release fails.                  | -                                                                                                                                                                       |
+| `skipPublish` | Skips the publish step so a GitLab release will not be created. This is useful if you only want to add comments for example. | `false` |
 
 #### assets
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,7 +18,16 @@ module.exports = async (pluginConfig, context) => {
     nextRelease: {gitTag, gitHead, notes},
     logger,
   } = context;
-  const {gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy} = resolveConfig(pluginConfig, context);
+  const {gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy, skipPublish} = resolveConfig(
+    pluginConfig,
+    context
+  );
+
+  if (skipPublish) {
+    logger.log('skipPublish option is set to %s, not publishing release to GitLab', skipPublish);
+    return;
+  }
+
   const assetsList = [];
   const repoId = getRepoId(context, gitlabUrl, repositoryUrl);
   const encodedRepoId = encodeURIComponent(repoId);

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -3,7 +3,18 @@ const urlJoin = require('url-join');
 const {HttpProxyAgent, HttpsProxyAgent} = require('hpagent');
 
 module.exports = (
-  {gitlabUrl, gitlabApiPathPrefix, assets, milestones, successComment, failTitle, failComment, labels, assignee},
+  {
+    gitlabUrl,
+    gitlabApiPathPrefix,
+    assets,
+    milestones,
+    successComment,
+    failTitle,
+    failComment,
+    labels,
+    assignee,
+    skipPublish,
+  },
   {
     envCi: {service} = {},
     env: {
@@ -50,6 +61,7 @@ module.exports = (
     failComment,
     labels: isNil(labels) ? 'semantic-release' : labels === false ? false : labels,
     assignee,
+    skipPublish,
   };
 };
 

--- a/test/resolve-config.test.js
+++ b/test/resolve-config.test.js
@@ -15,6 +15,7 @@ const defaultOptions = {
   labels: 'semantic-release',
   assignee: undefined,
   proxy: {},
+  skipPublish: undefined,
 };
 
 test('Returns user config', (t) => {


### PR DESCRIPTION
this adds a simple flag to skip the publish step which is useful for when you have development packages that don't need a gitlab release but would benefit from having the success comment.