### PR TITLE
fix: use numeric project ID for API calls

### DIFF
--- a/lib/get-repo-id.js
+++ b/lib/get-repo-id.js
@@ -1,9 +1,9 @@
 import parseUrl from "parse-url";
 import escapeStringRegexp from "escape-string-regexp";
 
-export default ({ envCi: { service } = {}, env: { CI_PROJECT_PATH } }, gitlabUrl, repositoryUrl) =>
-  service === "gitlab" && CI_PROJECT_PATH
-    ? CI_PROJECT_PATH
+export default ({ envCi: { service } = {}, env: { CI_PROJECT_ID } }, gitlabUrl, repositoryUrl) =>
+  service === "gitlab" && CI_PROJECT_ID
+    ? CI_PROJECT_ID
     : parseUrl(repositoryUrl)
         .pathname.replace(new RegExp(`^${escapeStringRegexp(parseUrl(gitlabUrl).pathname)}`), "")
         .replace(/^\//, "")

--- a/test/get-repo-id.test.js
+++ b/test/get-repo-id.test.js
@@ -41,18 +41,18 @@ test("Parse repo id with organization and subgroup", (t) => {
 test("Get repo id from GitLab CI", (t) => {
   t.is(
     getRepoId(
-      { envCi: { service: "gitlab" }, env: { CI_PROJECT_PATH: "other-owner/other-repo" } },
+      { envCi: { service: "gitlab" }, env: { CI_PROJECT_ID: "123" } },
       "https://gitlbab.com",
       "https://gitlab.com/owner/repo.git"
     ),
-    "other-owner/other-repo"
+    "123"
   );
 });
 
-test("Ignore CI_PROJECT_PATH if not on GitLab CI", (t) => {
+test("Ignore CI_PROJECT_ID if not on GitLab CI", (t) => {
   t.is(
     getRepoId(
-      { envCi: { service: "travis" }, env: { CI_PROJECT_PATH: "other-owner/other-repo" } },
+      { envCi: { service: "travis" }, env: { CI_PROJECT_ID: "123" } },
       "https://gitlbab.com",
       "https://gitlab.com/owner/repo.git"
     ),


### PR DESCRIPTION
Before we used the project path, which can cause issues with some proxy or firewall setups that replace slashes in URLs.

Closes https://github.com/semantic-release/gitlab/issues/543