### PR TITLE
fix: use project path for API calls again

### DIFF
--- a/lib/get-repo-id.js
+++ b/lib/get-repo-id.js
@@ -1,9 +1,9 @@
 import parseUrl from "parse-url";
 import escapeStringRegexp from "escape-string-regexp";
 
-export default ({ envCi: { service } = {}, env: { CI_PROJECT_ID } }, gitlabUrl, repositoryUrl) =>
-  service === "gitlab" && CI_PROJECT_ID
-    ? CI_PROJECT_ID
+export default ({ envCi: { service } = {}, env: { CI_PROJECT_PATH } }, gitlabUrl, repositoryUrl) =>
+  service === "gitlab" && CI_PROJECT_PATH
+    ? CI_PROJECT_PATH
     : parseUrl(repositoryUrl)
         .pathname.replace(new RegExp(`^${escapeStringRegexp(parseUrl(gitlabUrl).pathname)}`), "")
         .replace(/^\//, "")

--- a/test/get-repo-id.test.js
+++ b/test/get-repo-id.test.js
@@ -41,18 +41,18 @@ test("Parse repo id with organization and subgroup", (t) => {
 test("Get repo id from GitLab CI", (t) => {
   t.is(
     getRepoId(
-      { envCi: { service: "gitlab" }, env: { CI_PROJECT_ID: "123" } },
+      { envCi: { service: "gitlab" }, env: { CI_PROJECT_PATH: "other-owner/other-repo" } },
       "https://gitlbab.com",
       "https://gitlab.com/owner/repo.git"
     ),
-    "123"
+    "other-owner/other-repo"
   );
 });
 
-test("Ignore CI_PROJECT_ID if not on GitLab CI", (t) => {
+test("Ignore CI_PROJECT_PATH if not on GitLab CI", (t) => {
   t.is(
     getRepoId(
-      { envCi: { service: "travis" }, env: { CI_PROJECT_ID: "123" } },
+      { envCi: { service: "travis" }, env: { CI_PROJECT_PATH: "other-owner/other-repo" } },
       "https://gitlbab.com",
       "https://gitlab.com/owner/repo.git"
     ),


### PR DESCRIPTION
The numeric project ID is not working for all cases and I don't have the capacity right now to think about a generic solution.

People that have issues with the project path can override `CI_PROJECT_PATH` for the semantic-release invocation. 

Reverts semantic-release/gitlab#576

Closes #579 

/cc @JedaiRussia @gaborauth 