### PR TITLE
fix: support other channels on generic_package

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,6 +11,7 @@ import resolveConfig from "./resolve-config.js";
 import getRepoId from "./get-repo-id.js";
 import getAssets from "./glob-assets.js";
 import { RELEASE_NAME } from "./definitions/constants.js";
+import semver from "semver";
 
 const isUrlScheme = (value) => /^(https|http|ftp):\/\//.test(value);
 
@@ -18,7 +19,7 @@ export default async (pluginConfig, context) => {
   const {
     cwd,
     options: { repositoryUrl },
-    nextRelease: { gitTag, gitHead, notes, version },
+    nextRelease: { gitTag, gitHead, notes, version, channel },
     logger,
   } = context;
   const { gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy } = resolveConfig(pluginConfig, context);
@@ -26,7 +27,6 @@ export default async (pluginConfig, context) => {
   const repoId = getRepoId(context, gitlabUrl, repositoryUrl);
   const encodedRepoId = encodeURIComponent(repoId);
   const encodedGitTag = encodeURIComponent(gitTag);
-  const encodedVersion = encodeURIComponent(version);
   const apiOptions = { headers: { "PRIVATE-TOKEN": gitlabToken } };
 
   debug("repoId: %o", repoId);
@@ -88,11 +88,14 @@ export default async (pluginConfig, context) => {
 
           if (target === "generic_package") {
             // Upload generic packages
-            const encodedLabel = encodeURIComponent(label);
+            const { major, minor, patch } = semver.parse(version);
+            const encodedVersion = `${major}.${minor}.${patch}`;
+            const encodedLabel = encodeURIComponent(label ?? version);
+            const encodedChannel = encodeURIComponent(channel ?? "release");
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
             uploadEndpoint = urlJoin(
               gitlabApiUrl,
-              `/projects/${encodedRepoId}/packages/generic/release/${encodedVersion}/${encodedLabel}?${
+              `/projects/${encodedRepoId}/packages/generic/${encodedChannel}/${encodedVersion}/${encodedLabel}?${
                 status ? `status=${status}&` : ""
               }select=package_file`
             );
@@ -109,7 +112,7 @@ export default async (pluginConfig, context) => {
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#download-package-file
             const url = urlJoin(
               gitlabApiUrl,
-              `/projects/${encodedRepoId}/packages/generic/release/${encodedVersion}/${encodedLabel}`
+              `/projects/${encodedRepoId}/packages/generic/${encodedChannel}/${encodedVersion}/${encodedLabel}`
             );
 
             assetsList.push({ label, alt: "release", url, type: "package", filepath });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "hpagent": "^1.0.0",
         "lodash-es": "^4.17.21",
         "parse-url": "^8.0.0",
+        "semver": "^7.3.2",
         "url-join": "^4.0.0"
       },
       "devDependencies": {
@@ -1544,6 +1545,33 @@
         "node": ">=16"
       }
     },
+    "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-commits-filter": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
@@ -2978,6 +3006,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-dir/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -3279,6 +3334,33 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -7585,13 +7667,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7614,6 +7692,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semver-diff/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver-regex": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
@@ -7624,18 +7729,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/serialize-error": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hpagent": "^1.0.0",
     "lodash-es": "^4.17.21",
     "parse-url": "^8.0.0",
+    "semver": "^7.3.2",
     "url-join": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The current `generic_package` upload does not satisfy what actual needs. We don't always release on the official `release` channel.

gitlab url format is
`/projects/:id/packages/generic/:package_name/:package_version/:file_name?status=:status`

What i did:
* `package_name` equal to `channel` (release, alpha, beta, rc, etc)
* `package_version` always requires in format `major.minor.patch` (required from gitlab generic package upload)
* `file_name` is treated as the label config (if the label value does not exist, it would take `version` value instead)