### PR TITLE
chore: bump minimum Node version to 20.8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.0.0
-          - 19
+          - 20.8.1 # minimum supported Node version
+          - 20
+          - 21
         os:
           - ubuntu-latest
           - macos-latest

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,8 +1,9 @@
-import { createReadStream, readFileSync } from "fs";
+import { readFileSync } from "fs";
 import pathlib from "path";
 import fs from "fs-extra";
 import { isPlainObject, template } from "lodash-es";
-import FormData from "form-data";
+import { FormData } from "formdata-node";
+import { fileFromPath } from "formdata-node/file-from-path";
 import urlJoin from "url-join";
 import got from "got";
 import _debug from "debug";
@@ -123,7 +124,7 @@ export default async (pluginConfig, context) => {
 
             try {
               const form = new FormData();
-              form.append("file", createReadStream(file));
+              form.append("file", await fileFromPath(file));
               response = await got.post(uploadEndpoint, { ...apiOptions, ...proxy, body: form }).json();
             } catch (error) {
               logger.error("An error occurred while uploading %s to the GitLab project uploads API:\n%O", file, error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "debug": "^4.0.0",
         "dir-glob": "^3.0.0",
         "escape-string-regexp": "^5.0.0",
-        "form-data": "^4.0.0",
+        "formdata-node": "^6.0.3",
         "fs-extra": "^11.0.0",
         "globby": "^14.0.0",
         "got": "^13.0.0",
@@ -33,7 +33,7 @@
         "tempy": "1.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -1029,11 +1029,6 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "dev": true
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/ava": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ava/-/ava-6.0.1.tgz",
@@ -1490,17 +1485,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -1871,14 +1855,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -2140,9 +2116,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2235,25 +2211,20 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
       "engines": {
         "node": ">= 14.17"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/from2": {
@@ -3446,25 +3417,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -8273,10 +8225,13 @@
       "dev": true
     },
     "node_modules/traverse": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
-      "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "^4.0.0",
     "dir-glob": "^3.0.0",
     "escape-string-regexp": "^5.0.0",
-    "form-data": "^4.0.0",
+    "formdata-node": "^6.0.3",
     "fs-extra": "^11.0.0",
     "globby": "^14.0.0",
     "got": "^13.0.0",
@@ -41,7 +41,7 @@
     "tempy": "1.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.8.1"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This bumps the minimum supported Node version to 20.8.1. Node 20 is the new LTS version and some of our dependencies already dropped supported for Node 18. Check out [our Node Support Policy](https://semantic-release.gitbook.io/semantic-release/support/node-support-policy) for how we handle Node versions.

BREAKING CHANGE: Node 18 and 19 are not supported anymore. Users have to upgrade to Node 20.8.1 or later.