### PR TITLE
ci(renovate): fixed the reference to the org-level config

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "renovate": {
     "extends": [
-      "github>semantic-release/.github"
+      "github>semantic-release/.github:renovate-config"
     ]
   }
 }


### PR DESCRIPTION
to better align with the recommendation for org-level presets: docs.renovatebot.com/config-presets/#grouporganization-level-presets