### PR TITLE
fix: adds some guards around branch name

### DIFF
--- a/lib/get-fail-comment.js
+++ b/lib/get-fail-comment.js
@@ -17,7 +17,7 @@ ${
 }`;
 
 export default (branch, errors) => `## :rotating_light: The automated release from the \`${
-  branch.name
+  branch === undefined ? "unknown" : branch.name || branch
 }\` branch failed. :rotating_light:
 
 I recommend you give this issue a high priority, so other packages depending on you can benefit from your bug fixes and new features again.
@@ -27,7 +27,7 @@ You can find below the list of errors reported by **semantic-release**. Each one
 Errors are usually caused by a misconfiguration or an authentication problem. With each error reported below you will find explanation and guidance to help you to resolve it.
 
 Once all the errors are resolved, **semantic-release** will release your package the next time you push a commit to the \`${
-  branch.name
+  branch === undefined ? "unknown" : branch.name || branch
 }\` branch. You can also manually restart the failed CI job that runs **semantic-release**.
 
 If you are not sure how to resolve this, here are some links that can help you:


### PR DESCRIPTION
There are scenarios where `branch` is not an object in the get-fail-commit function To protect against this we add a few guards in the event that it could be any of an object a string or undefined