### PR TITLE
fix(fail): properly parse issue creation response to log in terminal

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -53,10 +53,12 @@ export default async (pluginConfig, context) => {
       debug("create issue: %O", newIssue);
 
       /* eslint camelcase: off */
-      const { id, web_url } = await got.post(issuesEndpoint, {
-        ...apiOptions,
-        json: newIssue,
-      });
+      const { id, web_url } = await got
+        .post(issuesEndpoint, {
+          ...apiOptions,
+          json: newIssue,
+        })
+        .json();
       logger.log("Created issue #%d: %s.", id, web_url);
     }
   }

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -72,11 +72,16 @@ Your **[semantic-release](https://github.com/semantic-release/semantic-release)*
       labels: "semantic-release",
       title: "The automated release is failing 🚨",
     })
-    .reply(200);
+    .reply(200, { id: 3, web_url: "https://gitlab.com/test_user/test_repo/-/issues/3" });
 
   await fail(pluginConfig, { env, options, branch, errors, logger: t.context.logger });
 
   t.true(gitlab.isDone());
+  t.deepEqual(t.context.log.args[0], [
+    "Created issue #%d: %s.",
+    3,
+    "https://gitlab.com/test_user/test_repo/-/issues/3",
+  ]);
 });
 
 test.serial("Post comments to existing issue", async (t) => {


### PR DESCRIPTION
I realized in our logs, the `id` and `web_url` are not parsed properly. According to the docs the call to the method `.json()` was missing. Local tests showed this fixed the logs and did not affect the normal functionality.