### PR TITLE
Replaced usage of assert keyword with "with" keyword to support node version 22.0.0

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -1,5 +1,5 @@
 import {inspect} from 'util';
-import pkg from '../../package.json' assert {type: 'json'};
+import pkg from '../../package.json' with {type: 'json'};
 
 const [homepage] = pkg.homepage.split('#');
 const linkify = (file) => `${homepage}/blob/master/${file}`;


### PR DESCRIPTION
Fixes https://github.com/semantic-release/gitlab/issues/704