### PR TITLE
fix: get rid of import assertion

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -1,6 +1,8 @@
 import {inspect} from 'util';
-import pkg from '../../package.json' assert {type: 'json'};
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 
+const pkg = require("../../package.json");
 const [homepage] = pkg.homepage.split('#');
 const linkify = (file) => `${homepage}/blob/master/${file}`;
 const stringify = (object) => inspect(object, {breakLength: Number.POSITIVE_INFINITY, depth: 2, maxArrayLength: 5});


### PR DESCRIPTION
Neither import assertions nor the with keyword is supported across our supported versions.

Instead of going for a breaking change and raise our Node dependency I suggest we apply the same logic as [in the GitHub plugin](https://github.com/semantic-release/github/blob/master/lib/definitions/errors.js#L7).

Resolves https://github.com/semantic-release/gitlab/issues/704