### PR TITLE
feat: improve output in case of errors during publish

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -28,7 +28,25 @@ export default async (pluginConfig, context) => {
   const encodedRepoId = encodeURIComponent(repoId);
   const encodedGitTag = encodeURIComponent(gitTag);
   const encodedVersion = encodeURIComponent(version);
-  const apiOptions = { headers: { "PRIVATE-TOKEN": gitlabToken } };
+  const apiOptions = {
+    headers: {
+      "PRIVATE-TOKEN": gitlabToken,
+    },
+    hooks: {
+      beforeError: [
+        (error) => {
+          const { response } = error;
+          if (response?.body && response.headers["content-type"] === "application/json") {
+            const parsedBody = JSON.parse(response.body);
+            if (parsedBody.message) {
+              error.message = `Response code ${response.statusCode} (${parsedBody.message})`;
+            }
+          }
+          return error;
+        },
+      ],
+    },
+  };
 
   debug("repoId: %o", repoId);
   debug("release name: %o", gitTag);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -617,3 +617,27 @@ test.serial("Publish a release with an asset link", async (t) => {
   t.deepEqual(t.context.log.args[0], ["Published GitLab release: %s", nextRelease.gitTag]);
   t.true(gitlab.isDone());
 });
+
+test.serial("Publish a release with error response", async (t) => {
+  const owner = "test_user";
+  const repo = "test_repo";
+  const env = { GITLAB_TOKEN: "gitlab_token" };
+  const pluginConfig = {};
+  const nextRelease = { gitHead: "123", gitTag: "v1.0.0", notes: "Test release note body" };
+  const options = { repositoryUrl: `https://gitlab.com/${owner}/${repo}.git` };
+  const encodedRepoId = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedRepoId}/releases`, {
+      tag_name: nextRelease.gitTag,
+      description: nextRelease.notes,
+      assets: {
+        links: [],
+      },
+    })
+    .reply(499, { message: "Something went wrong" });
+
+  const error = await t.throwsAsync(publish(pluginConfig, { env, options, nextRelease, logger: t.context.logger }));
+  t.is(error.message, `Response code 499 (Something went wrong)`);
+  t.true(gitlab.isDone());
+});


### PR DESCRIPTION
This PR adds the message from the response body to the error if available.

Resolves https://github.com/semantic-release/gitlab/issues/684