### PR TITLE
fix: updated configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
           { "path": "dist/asset.min.css", "label": "CSS distribution" },
           { "path": "dist/asset.min.js", "label": "JS distribution", "target": "generic_package" },
           { "path": "dist/asset.min.js", "label": "v${nextRelease.version}.js" },
-          { "url": "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md" }
+          { "url": "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md", "label": "README.md" }
         ]
       }
     ]


### PR DESCRIPTION
Add assets label for url otherwise release is not created because GitLab API expect a assets:links:name.

https://docs.gitlab.com/ee/api/releases/#create-a-release