### PR TITLE
Handle ci/cd job token

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -6,6 +6,7 @@ const debug = _debug("semantic-release:gitlab");
 import resolveConfig from "./resolve-config.js";
 import getFailComment from "./get-fail-comment.js";
 import getProjectContext from "./get-project-context.js";
+import getTokenHeader from "./get-token-header.js"
 
 export default async (pluginConfig, context) => {
   const {
@@ -28,7 +29,7 @@ export default async (pluginConfig, context) => {
   const { encodedProjectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
   const apiOptions = {
-    headers: { "PRIVATE-TOKEN": gitlabToken },
+    headers: { [getTokenHeader(gitlabToken)]: gitlabToken },
     retry: { limit: retryLimit },
   };
 

--- a/lib/get-token-header.js
+++ b/lib/get-token-header.js
@@ -1,0 +1,8 @@
+export default (token) => {
+    switch(true) {
+        case token.startsWith("glcbt-"):
+          return "JOB-TOKEN"
+        default:
+          return "PRIVATE-TOKEN"
+      }
+};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -12,6 +12,7 @@ import resolveConfig from "./resolve-config.js";
 import getAssets from "./glob-assets.js";
 import { RELEASE_NAME } from "./definitions/constants.js";
 import getProjectContext from "./get-project-context.js";
+import getTokenHeader from "./get-token-header.js"
 
 const isUrlScheme = (value) => /^(https|http|ftp):\/\//.test(value);
 
@@ -33,7 +34,7 @@ export default async (pluginConfig, context) => {
   const encodedVersion = encodeURIComponent(version);
   const apiOptions = {
     headers: {
-      "PRIVATE-TOKEN": gitlabToken,
+      [getTokenHeader(gitlabToken)]: gitlabToken,
     },
     hooks: {
       beforeError: [

--- a/lib/success.js
+++ b/lib/success.js
@@ -6,6 +6,7 @@ const debug = _debug("semantic-release:gitlab");
 import resolveConfig from "./resolve-config.js";
 import getProjectContext from "./get-project-context.js";
 import getSuccessComment from "./get-success-comment.js";
+import getTokenHeader from "./get-token-header.js"
 
 export default async (pluginConfig, context) => {
   const {
@@ -19,7 +20,7 @@ export default async (pluginConfig, context) => {
     resolveConfig(pluginConfig, context);
   const { projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
   const apiOptions = {
-    headers: { "PRIVATE-TOKEN": gitlabToken },
+    headers: { [getTokenHeader(gitlabToken)]: gitlabToken },
     retry: { limit: retryLimit },
   };
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -54,17 +54,25 @@ export default async (pluginConfig, context) => {
   }
 
   if (gitlabToken && projectPath) {
+    let tokenHeader;
     let projectAccess;
     let groupAccess;
 
     logger.log("Verify GitLab authentication (%s)", gitlabApiUrl);
+
+    switch(true) {
+      case str.startsWith("glcbt-"):
+        tokenHeader = "JOB-TOKEN"
+      default:
+        tokenHeader = "PRIVATE-TOKEN"
+    }
 
     try {
       ({
         permissions: { project_access: projectAccess, group_access: groupAccess },
       } = await got
         .get(projectApiUrl, {
-          headers: { "PRIVATE-TOKEN": gitlabToken },
+          headers: { tokenHeader: gitlabToken },
           ...proxy,
         })
         .json());

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -6,6 +6,7 @@ import AggregateError from "aggregate-error";
 import resolveConfig from "./resolve-config.js";
 import getProjectContext from "./get-project-context.js";
 import getError from "./get-error.js";
+import getTokenHeader from "./get-token-header.js"
 
 const isNonEmptyString = (value) => isString(value) && value.trim();
 const isStringOrStringArray = (value) =>
@@ -54,25 +55,17 @@ export default async (pluginConfig, context) => {
   }
 
   if (gitlabToken && projectPath) {
-    let tokenHeader;
     let projectAccess;
     let groupAccess;
 
     logger.log("Verify GitLab authentication (%s)", gitlabApiUrl);
-
-    switch(true) {
-      case str.startsWith("glcbt-"):
-        tokenHeader = "JOB-TOKEN"
-      default:
-        tokenHeader = "PRIVATE-TOKEN"
-    }
 
     try {
       ({
         permissions: { project_access: projectAccess, group_access: groupAccess },
       } = await got
         .get(projectApiUrl, {
-          headers: { tokenHeader: gitlabToken },
+          headers: { [getTokenHeader(gitlabToken)]: gitlabToken },
           ...proxy,
         })
         .json());

--- a/test/helpers/mock-gitlab.js
+++ b/test/helpers/mock-gitlab.js
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import urlJoin from 'url-join';
+import getTokenHeader from "./get-token-header.js"
 
 /**
  * Retun a `nock` object setup to respond to a GitLab authentication request. Other expectation and responses can be chained.
@@ -22,5 +23,5 @@ export default function (
       : null || '/api/v4',
   } = {}
 ) {
-  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), {reqheaders: {'Private-Token': gitlabToken}});
+  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), {reqheaders: {[getTokenHeader(gitlabToken)]: gitlabToken}});
 };


### PR DESCRIPTION
Handle ci/cd job token to allow the use of the Gitlab CI/CD token having push rights in the repository (incoming feature)

- https://gitlab.com/gitlab-org/gitlab/-/issues/475705#note_2461866773
- https://gitlab.com/gitlab-org/gitlab/-/issues/468320

Related to https://github.com/semantic-release/gitlab/issues/156