### PR TITLE
fix(retry): also handle status code 422 #839

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -24,12 +24,16 @@ export default async (pluginConfig, context) => {
     labels,
     assignee,
     retryLimit,
+    retryStatusCodes,
   } = resolveConfig(pluginConfig, context);
   const { encodedProjectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
   const apiOptions = {
     headers: { "PRIVATE-TOKEN": gitlabToken },
-    retry: { limit: retryLimit },
+    retry: {
+      limit: retryLimit,
+      statusCodes: retryStatusCodes,
+    },
   };
 
   if (failComment === false || failTitle === false) {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,10 +22,8 @@ export default async (pluginConfig, context) => {
     nextRelease: { gitTag, gitHead, notes, version },
     logger,
   } = context;
-  const { gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy, retryLimit } = resolveConfig(
-    pluginConfig,
-    context
-  );
+  const { gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy, retryLimit, retryStatusCodes } =
+    resolveConfig(pluginConfig, context);
   const assetsList = [];
   const { projectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
@@ -49,7 +47,7 @@ export default async (pluginConfig, context) => {
         },
       ],
     },
-    retry: { limit: retryLimit },
+    retry: { limit: retryLimit, statusCodes: retryStatusCodes },
   };
 
   debug("projectPath: %o", projectPath);

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -36,6 +36,9 @@ export default (
   }
 ) => {
   const DEFAULT_RETRY_LIMIT = 3;
+  // Added 422 to fix #839
+  // https://github.com/sindresorhus/got/blob/a359bd385129d2adbc765b52dfbbadac5f54a825/documentation/7-retry.md#retry
+  const DEFAULT_RETRY_STATUS_CODES = [408, 413, 422, 429, 500, 502, 503, 504, 521, 522, 524];
   const userGitlabApiPathPrefix = isNil(gitlabApiPathPrefix)
     ? isNil(GL_PREFIX)
       ? GITLAB_PREFIX
@@ -67,6 +70,7 @@ export default (
     labels: isNil(labels) ? "semantic-release" : labels === false ? false : labels,
     assignee,
     retryLimit: retryLimit ?? DEFAULT_RETRY_LIMIT,
+    retryStatusCodes: DEFAULT_RETRY_STATUS_CODES,
   };
 };
 

--- a/lib/success.js
+++ b/lib/success.js
@@ -15,12 +15,20 @@ export default async (pluginConfig, context) => {
     commits,
     releases,
   } = context;
-  const { gitlabToken, gitlabUrl, gitlabApiUrl, successComment, successCommentCondition, proxy, retryLimit } =
-    resolveConfig(pluginConfig, context);
+  const {
+    gitlabToken,
+    gitlabUrl,
+    gitlabApiUrl,
+    successComment,
+    successCommentCondition,
+    proxy,
+    retryLimit,
+    retryStatusCodes,
+  } = resolveConfig(pluginConfig, context);
   const { projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
   const apiOptions = {
     headers: { "PRIVATE-TOKEN": gitlabToken },
-    retry: { limit: retryLimit },
+    retry: { limit: retryLimit, statusCodes: retryStatusCodes },
   };
 
   if (successComment === false) {

--- a/test/resolve-config.test.js
+++ b/test/resolve-config.test.js
@@ -18,6 +18,7 @@ const defaultOptions = {
   assignee: undefined,
   proxy: {},
   retryLimit: 3,
+  retryStatusCodes: [408, 413, 422, 429, 500, 502, 503, 504, 521, 522, 524],
 };
 
 test("Returns user config", (t) => {


### PR DESCRIPTION
> https://github.com/sindresorhus/got/blob/a359bd385129d2adbc765b52dfbbadac5f54a825/documentation/7-retry.md#retry

This could fix #839. Processing creation of tags could take longer then the time between the API requests. Adding the status code `422` to the retry configuration could solve this problem as it uses three attempts with additional time between the attempts.