### PR TITLE
feat: enable support for creating release tag via release api

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Ensure your project is configured to [allow git push requests for job tokens](ht
 
 **Note**: Due to limitations on [job token](https://docs.gitlab.com/ci/jobs/ci_job_token/) access, comments on merge requests and issues must be explicitly disabled. See: [successCommentCondition](#successcommentcondition) and [failCommentCondition](#failcommentcondition).
 
+#### Skip Push Support
+It is possible to use a Job Token *without* git push permissions, by using the `skipPush` option. In this mode, the repository tag will be created by the GitLab release api.
+
+**Note**: **semantic-release** relies on git notes for tracking the [release channels](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel) associated with releases. It is not possible to push these notes via the GitLab release api; therefore, all branches must be configured to use the default channel. 
+
+
 ### Environment variables
 
 | Variable                       | Description                                                                                |

--- a/README.md
+++ b/README.md
@@ -54,9 +54,18 @@ With this example [GitLab releases](https://docs.gitlab.com/ee/user/project/rele
 The GitLab authentication configuration is **required** and can be set via
 [environment variables](#environment-variables).
 
+There are two types of tokens supported by GitLab:
+
+#### Access Token
+
 Create a [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html), [group access token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html), or [personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html) with role _Developer_ (or higher) and the `api` scope and make it available in your CI environment via the `GL_TOKEN` environment variable. If you are using `GL_TOKEN` as the [remote Git repository authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) it must also have the `write_repository` scope.
 
 **Note**: When running with [`dryRun`](https://semantic-release.gitbook.io/semantic-release/usage/configuration#dryrun) only `read_repository` scope is required.
+
+#### Job Token
+Ensure your project is configured to [allow git push requests for job tokens](https://docs.gitlab.com/ci/jobs/ci_job_token/#allow-git-push-requests-to-your-project-repository), and assign the value of `CI_JOB_TOKEN` to `GL_TOKEN`.
+
+**Note**: Due to limitations on [job token](https://docs.gitlab.com/ci/jobs/ci_job_token/) access, comments on merge requests and issues must be explicitly disabled. See: [successCommentCondition](#successcommentcondition) and [failCommentCondition](#failcommentcondition).
 
 ### Environment variables
 

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -49,13 +49,13 @@ By default the \`repositoryUrl\` option is retrieved from the \`repository\` pro
     message: 'Invalid GitLab token.',
     details: `The [GitLab token](${linkify(
       'README.md#gitlab-authentication'
-    )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must be a valid [personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html) allowing to push to the repository ${projectPath}.
+    )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must be a valid [ci job token](https://docs.gitlab.com/ci/jobs/ci_job_token/), [group access token](https://docs.gitlab.com/user/group/settings/group_access_tokens/), [project access token](https://docs.gitlab.com/user/project/settings/project_access_tokens/), or [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/) with access to the repository ${projectPath}.
 
-Please make sure to set the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable in your CI with the exact value of the GitLab personal token.`,
+Please make sure to set the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable in your CI with the exact value of the GitLab token.`,
   }),
   EMISSINGREPO: ({projectPath}) => ({
     message: `The repository ${projectPath} doesn't exist.`,
-    details: `The **semantic-release** \`repositoryUrl\` option must refer to your GitLab repository. The repository must be accessible with the [GitLab API](https://docs.gitlab.com/ce/api/README.html).
+    details: `The **semantic-release** \`repositoryUrl\` option must refer to your GitLab repository. The repository must be accessible with the [GitLab API](https://docs.gitlab.com/api/rest/).
 
 By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.
 
@@ -65,15 +65,15 @@ If you are using [GitLab Enterprise Edition](https://about.gitlab.com/gitlab-ee)
   }),
   EGLNOPUSHPERMISSION: ({projectPath}) => ({
     message: `The GitLab token doesn't allow to push on the repository ${projectPath}.`,
-    details: `The user associated with the [GitLab token](${linkify(
+    details: `The access associated with the [GitLab token](${linkify(
       'README.md#gitlab-authentication'
-    )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must allows to push to the repository ${projectPath}.
+    )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must allow push to the repository ${projectPath}.
 
 Please make sure the GitLab user associated with the token has the [permission to push](https://docs.gitlab.com/ee/user/permissions.html#project-members-permissions) to the repository ${projectPath}.`,
   }),
   EGLNOPULLPERMISSION: ({projectPath}) => ({
     message: `The GitLab token doesn't allow to pull from the repository ${projectPath}.`,
-    details: `The user associated with the [GitLab token](${linkify(
+    details: `The access associated with the [GitLab token](${linkify(
       'README.md#gitlab-authentication'
     )}) configured in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable must allow pull from the repository ${projectPath}.
 
@@ -85,6 +85,13 @@ Please make sure the GitLab user associated with the token has the [permission t
       'README.md#gitlab-authentication'
     )}) must be created and set in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable on your CI environment.
 
-Please make sure to create a [GitLab personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html) and to set it in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable on your CI environment. The token must allow to push to the repository ${repositoryUrl}.`,
+Please make sure to create a [group access token](https://docs.gitlab.com/user/group/settings/group_access_tokens/), [project access token](https://docs.gitlab.com/user/project/settings/project_access_tokens/), [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/), or utilize the [ci job token](https://docs.gitlab.com/ci/jobs/ci_job_token/)  and to set it in the \`GL_TOKEN\` or \`GITLAB_TOKEN\` environment variable on your CI environment. The token must allow access to the repository ${repositoryUrl}.`,
+  }),
+
+  EJOBTOKENCOMMENTCONDITION: ({projectPath}) => ({
+    message: 'Invalid comment conditions using job token.',
+    details: `When using a [job token](https://docs.gitlab.com/ci/jobs/ci_job_token/), [successCommentCondition](${linkify('README.md#successCommentCondition')}) and [failCommentCondition](${linkify('README.md#failCommentCondition')}) must be explicitly set to \`false\`, as job tokens do not have permissions to comment on issues and merge requests.
+
+Please explicitly disable this function, or use a [group access token](https://docs.gitlab.com/user/group/settings/group_access_tokens/), [project access token](https://docs.gitlab.com/user/project/settings/project_access_tokens/), or [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/) with access to the repository ${projectPath}`,
   }),
 };

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -94,4 +94,11 @@ Please make sure to create a [group access token](https://docs.gitlab.com/user/g
 
 Please explicitly disable this function, or use a [group access token](https://docs.gitlab.com/user/group/settings/group_access_tokens/), [project access token](https://docs.gitlab.com/user/project/settings/project_access_tokens/), or [personal access token](https://docs.gitlab.com/user/profile/personal_access_tokens/) with access to the repository ${projectPath}`,
   }),
+
+  ESKIPPUSHCHANNEL: ({branchName}) => ({
+    message: 'Invalid branch channel configuration using skipPush.',
+    details: `With skipPush enabled, all branches must utilize the default release channel.
+
+Please explicitly set the ${branchName} branch to use the default release channel, or disable skipPush`,
+  }),
 };

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -16,6 +16,7 @@ export default async (pluginConfig, context) => {
   } = context;
   const {
     gitlabToken,
+    tokenHeader,
     gitlabUrl,
     gitlabApiUrl,
     failComment,
@@ -29,7 +30,7 @@ export default async (pluginConfig, context) => {
   const { encodedProjectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
   const apiOptions = {
-    headers: { "PRIVATE-TOKEN": gitlabToken },
+    headers: { [tokenHeader]: gitlabToken },
     retry: {
       limit: retryLimit,
       statusCodes: retryStatusCodes,

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,7 +18,7 @@ const isUrlScheme = (value) => /^(https|http|ftp):\/\//.test(value);
 export default async (pluginConfig, context) => {
   const {
     cwd,
-    options: { repositoryUrl },
+    options: { repositoryUrl, skipPush },
     nextRelease: { gitTag, gitHead, notes, version },
     logger,
   } = context;
@@ -167,6 +167,7 @@ export default async (pluginConfig, context) => {
   const json = {
     /* eslint-disable camelcase */
     tag_name: gitTag,
+    ...(skipPush && { ref: gitHead }),
     description: notes && notes.trim() ? notes : gitTag,
     milestones,
     assets: {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,7 +22,7 @@ export default async (pluginConfig, context) => {
     nextRelease: { gitTag, gitHead, notes, version },
     logger,
   } = context;
-  const { gitlabToken, gitlabUrl, gitlabApiUrl, assets, milestones, proxy, retryLimit, retryStatusCodes } =
+  const { gitlabToken, tokenHeader, gitlabUrl, gitlabApiUrl, assets, milestones, proxy, retryLimit, retryStatusCodes } =
     resolveConfig(pluginConfig, context);
   const assetsList = [];
   const { projectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
@@ -31,7 +31,7 @@ export default async (pluginConfig, context) => {
   const encodedVersion = encodeURIComponent(version);
   const apiOptions = {
     headers: {
-      "PRIVATE-TOKEN": gitlabToken,
+      [tokenHeader]: gitlabToken,
     },
     hooks: {
       beforeError: [

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -23,6 +23,7 @@ export default (
       CI_PROJECT_URL,
       CI_PROJECT_PATH,
       CI_API_V4_URL,
+      CI_JOB_TOKEN,
       GL_TOKEN,
       GITLAB_TOKEN,
       GL_URL,
@@ -52,6 +53,8 @@ export default (
       : "https://gitlab.com");
   return {
     gitlabToken: GL_TOKEN || GITLAB_TOKEN,
+    isJobToken: (!!CI_JOB_TOKEN && (GL_TOKEN || GITLAB_TOKEN) === CI_JOB_TOKEN),
+    tokenHeader: (!!CI_JOB_TOKEN && (GL_TOKEN || GITLAB_TOKEN) === CI_JOB_TOKEN) ? "JOB-TOKEN" : "PRIVATE-TOKEN",
     gitlabUrl: defaultedGitlabUrl,
     gitlabApiUrl:
       userGitlabUrl && userGitlabApiPathPrefix

--- a/lib/success.js
+++ b/lib/success.js
@@ -17,6 +17,7 @@ export default async (pluginConfig, context) => {
   } = context;
   const {
     gitlabToken,
+    tokenHeader,
     gitlabUrl,
     gitlabApiUrl,
     successComment,
@@ -27,7 +28,7 @@ export default async (pluginConfig, context) => {
   } = resolveConfig(pluginConfig, context);
   const { projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
   const apiOptions = {
-    headers: { "PRIVATE-TOKEN": gitlabToken },
+    headers: { [tokenHeader]: gitlabToken },
     retry: { limit: retryLimit, statusCodes: retryStatusCodes },
   };
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -6,6 +6,7 @@ import AggregateError from "aggregate-error";
 import resolveConfig from "./resolve-config.js";
 import getProjectContext from "./get-project-context.js";
 import getError from "./get-error.js";
+import urlJoin from "url-join";
 
 const isNonEmptyString = (value) => isString(value) && value.trim();
 const isStringOrStringArray = (value) =>
@@ -30,7 +31,10 @@ export default async (pluginConfig, context) => {
     options: { repositoryUrl },
     logger,
   } = context;
-  const { gitlabToken, gitlabUrl, gitlabApiUrl, proxy, ...options } = resolveConfig(pluginConfig, context);
+  const { gitlabToken, isJobToken, tokenHeader, successCommentCondition, failCommentCondition, gitlabUrl, gitlabApiUrl, proxy, ...options } = resolveConfig(
+    pluginConfig,
+    context
+  );
   const { projectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
   debug("apiUrl: %o", gitlabApiUrl);
@@ -53,6 +57,10 @@ export default async (pluginConfig, context) => {
     errors.push(getError("ENOGLTOKEN", { repositoryUrl }));
   }
 
+  if (isJobToken && !(failCommentCondition === false) && !(successCommentCondition === false)) {
+    errors.push(getError("EJOBTOKENCOMMENTCONDITION", { projectPath }))
+  }
+
   if (gitlabToken && projectPath) {
     let projectAccess;
     let groupAccess;
@@ -60,23 +68,27 @@ export default async (pluginConfig, context) => {
     logger.log("Verify GitLab authentication (%s)", gitlabApiUrl);
 
     try {
-      ({
-        permissions: { project_access: projectAccess, group_access: groupAccess },
-      } = await got
-        .get(projectApiUrl, {
-          headers: { "PRIVATE-TOKEN": gitlabToken },
-          ...proxy,
-        })
-        .json());
-      if (
-        context.options.dryRun &&
-        !((projectAccess && projectAccess.access_level >= 10) || (groupAccess && groupAccess.access_level >= 10))
-      ) {
-        errors.push(getError("EGLNOPULLPERMISSION", { projectPath }));
-      } else if (
-        !((projectAccess && projectAccess.access_level >= 30) || (groupAccess && groupAccess.access_level >= 30))
-      ) {
-        errors.push(getError("EGLNOPUSHPERMISSION", { projectPath }));
+      if (isJobToken) {
+        await got.get(urlJoin(projectApiUrl, "releases"), { headers: { [tokenHeader]: gitlabToken } });
+      } else {
+        ({
+          permissions: { project_access: projectAccess, group_access: groupAccess },
+        } = await got
+          .get(projectApiUrl, {
+            headers: { [tokenHeader]: gitlabToken },
+            ...proxy,
+          })
+          .json());
+        if (
+          context.options.dryRun &&
+          !((projectAccess && projectAccess.access_level >= 10) || (groupAccess && groupAccess.access_level >= 10))
+        ) {
+          errors.push(getError("EGLNOPULLPERMISSION", { projectPath }));
+        } else if (
+          !((projectAccess && projectAccess.access_level >= 30) || (groupAccess && groupAccess.access_level >= 30))
+        ) {
+          errors.push(getError("EGLNOPUSHPERMISSION", { projectPath }));
+        }
       }
     } catch (error) {
       if (error.response && error.response.statusCode === 401) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -28,8 +28,9 @@ const VALIDATORS = {
 
 export default async (pluginConfig, context) => {
   const {
-    options: { repositoryUrl },
+    options: { repositoryUrl, skipPush },
     logger,
+    branches,
   } = context;
   const { gitlabToken, isJobToken, tokenHeader, successCommentCondition, failCommentCondition, gitlabUrl, gitlabApiUrl, proxy, ...options } = resolveConfig(
     pluginConfig,
@@ -59,6 +60,14 @@ export default async (pluginConfig, context) => {
 
   if (isJobToken && !(failCommentCondition === false) && !(successCommentCondition === false)) {
     errors.push(getError("EJOBTOKENCOMMENTCONDITION", { projectPath }))
+  }
+
+  if (skipPush && branches.length > 0) {
+    branches.forEach((branch) => {
+      if (branch.channel) {
+        errors.push(getError("ESKIPPUSHCHANNEL", { branchName: branch.name }))
+      }
+    });
   }
 
   if (gitlabToken && projectPath) {

--- a/test/helpers/mock-gitlab.js
+++ b/test/helpers/mock-gitlab.js
@@ -22,5 +22,5 @@ export default function (
       : null || '/api/v4',
   } = {}
 ) {
-  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), {reqheaders: {'Private-Token': gitlabToken}});
+  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), {reqheaders: {[gitlabToken === env.CI_JOB_TOKEN ? "Job-Token" : "Private-Token"]: gitlabToken}});
 };

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -45,6 +45,33 @@ test.serial("Publish a release", async (t) => {
   t.true(gitlab.isDone());
 });
 
+test.serial("Publish a release with skipPush enabled", async (t) => {
+  const owner = "test_user";
+  const repo = "test_repo";
+  const env = { GITLAB_TOKEN: "gitlab_token" };
+  const pluginConfig = {};
+  const nextRelease = { gitHead: "123", gitTag: "v1.0.0", notes: "Test release note body" };
+  const options = { repositoryUrl: `https://gitlab.com/${owner}/${repo}.git`, skipPush: true };
+  const encodedProjectPath = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedProjectPath}/releases`, {
+      tag_name: nextRelease.gitTag,
+      ref: nextRelease.gitHead,
+      description: nextRelease.notes,
+      assets: {
+        links: [],
+      },
+    })
+    .reply(200);
+
+  const result = await publish(pluginConfig, { env, options, nextRelease, logger: t.context.logger });
+
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
+  t.deepEqual(t.context.log.args[0], ["Published GitLab release: %s", nextRelease.gitTag]);
+  t.true(gitlab.isDone());
+});
+
 test.serial("Publish a release with templated path", async (t) => {
   const cwd = "test/fixtures/files";
   const owner = "test_user";

--- a/test/resolve-config.test.js
+++ b/test/resolve-config.test.js
@@ -5,6 +5,8 @@ import resolveConfig from "../lib/resolve-config.js";
 
 const defaultOptions = {
   gitlabToken: undefined,
+  isJobToken: false,
+  tokenHeader: "PRIVATE-TOKEN",
   gitlabUrl: "https://gitlab.com",
   gitlabApiUrl: urlJoin("https://gitlab.com", "/api/v4"),
   assets: undefined,
@@ -505,6 +507,26 @@ test("Ignore GitLab CI/CD environment variables if not running on GitLab CI/CD",
       gitlabToken,
       gitlabUrl: "https://gitlab.com",
       gitlabApiUrl: urlJoin("https://gitlab.com", "/api/v4"),
+    }
+  );
+});
+
+test("Use job token when GitLab token equals CI_JOB_TOKEN", (t) => {
+  const jobToken = "TOKEN"
+
+  t.deepEqual(
+    resolveConfig(
+      {},
+      {
+        envCi: { service: "gitlab" },
+        env: { GL_TOKEN: jobToken, CI_JOB_TOKEN: jobToken },
+      }
+    ),
+    {
+      ...defaultOptions,
+      gitlabToken: jobToken,
+      isJobToken: true,
+      tokenHeader: "JOB-TOKEN",
     }
   );
 });


### PR DESCRIPTION
Enables creation of release tag via the `ref` field of the release api.

Implements a verification check to ensure all branches are set to use the default release channel (as notes cannot be pushed)

Depends on: https://github.com/semantic-release/semantic-release/pull/3760