### PR TITLE
fix: added support for generic package name

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -75,6 +75,7 @@ export default async (pluginConfig, context) => {
         const type = asset.type ? template(asset.type)(context) : undefined;
         const filepath = asset.filepath ? template(asset.filepath)(context) : undefined;
         const target = asset.target ? template(asset.target)(context) : undefined;
+        const packageName = asset.packageName ? template(asset.packageName)(context) : "release";
         const status = asset.status ? template(asset.status)(context) : undefined;
 
         if (_url) {
@@ -102,6 +103,7 @@ export default async (pluginConfig, context) => {
           debug("file type: %o", type);
           debug("file filepath: %o", filepath);
           debug("file target: %o", target);
+          debug("file packageName: %o", packageName);
           debug("file status: %o", status);
 
           let uploadEndpoint;
@@ -110,10 +112,11 @@ export default async (pluginConfig, context) => {
           if (target === "generic_package") {
             // Upload generic packages
             const encodedLabel = encodeURIComponent(label);
+            const encodedPackageName = encodeURIComponent(packageName);
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
             uploadEndpoint = urlJoin(
               projectApiUrl,
-              `packages/generic/release/${encodedVersion}/${encodedLabel}?${
+              `packages/generic/${encodedPackageName}/${encodedVersion}/${encodedLabel}?${
                 status ? `status=${status}&` : ""
               }select=package_file`
             );
@@ -128,9 +131,9 @@ export default async (pluginConfig, context) => {
             }
 
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#download-package-file
-            const url = urlJoin(projectApiUrl, `packages/generic/release/${encodedVersion}/${encodedLabel}`);
+            const url = urlJoin(projectApiUrl, `packages/generic/${encodedPackageName}/${encodedVersion}/${encodedLabel}`);
 
-            assetsList.push({ label, alt: "release", url, type: "package", filepath });
+            assetsList.push({ label, alt: packageName, url, type: "package", filepath });
 
             logger.log("Uploaded file: %s (%s)", url, response.file.url);
           } else {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -176,6 +176,53 @@ test.serial("Publish a release with generics", async (t) => {
   t.true(gitlab.isDone());
 });
 
+test.serial("Publish a release with generics, providing a packageName", async (t) => {
+  const cwd = "test/fixtures/files";
+  const owner = "test_user";
+  const repo = "test_repo";
+  const env = { GITLAB_TOKEN: "gitlab_token" };
+  const nextRelease = { gitHead: "123", gitTag: "v1.0.0", notes: "Test release note body", version: "1.0.0" };
+  const options = { repositoryUrl: `https://gitlab.com/${owner}/${repo}.git` };
+  const encodedProjectPath = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const encodedVersion = encodeURIComponent(nextRelease.version);
+  const uploaded = { file: { url: "/uploads/file.css" } };
+  const generic = { path: "file.css", label: "Style package", target: "generic_package", status: "hidden", packageName: "styles" };
+  const assets = [generic];
+  const encodedLabel = encodeURIComponent(generic.label);
+  const encodedPackageName = encodeURIComponent(generic.packageName);
+  const expectedUrl = `https://gitlab.com/api/v4/projects/${encodedProjectPath}/packages/generic/${encodedPackageName}/${encodedVersion}/${encodedLabel}`;
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedProjectPath}/releases`, {
+      tag_name: nextRelease.gitTag,
+      description: nextRelease.notes,
+      assets: {
+        links: [
+          {
+            name: "Style package",
+            url: expectedUrl,
+            link_type: "package",
+          },
+        ],
+      },
+    })
+    .reply(200);
+  const gitlabUpload = authenticate(env)
+    .put(
+      `/projects/${encodedProjectPath}/packages/generic/${encodedPackageName}/${encodedVersion}/${encodedLabel}?status=${generic.status}&select=package_file`,
+      /\.test\s\{\}/gm
+    )
+    .reply(200, uploaded);
+
+  const result = await publish({ assets }, { env, cwd, options, nextRelease, logger: t.context.logger });
+
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
+  t.deepEqual(t.context.log.args[0], ["Uploaded file: %s (%s)", expectedUrl, uploaded.file.url]);
+  t.deepEqual(t.context.log.args[1], ["Published GitLab release: %s", nextRelease.gitTag]);
+  t.true(gitlabUpload.isDone());
+  t.true(gitlab.isDone());
+});
+
 test.serial("Publish a release with generics and external storage provider (http)", async (t) => {
   const cwd = "test/fixtures/files";
   const owner = "test_user";


### PR DESCRIPTION
The current version of this project doesn't support custom generic packages names, instead publishes them under the `release` package.

When publishing generic packages to the package repository on Gitlab, you are able to specify the name of your package in the URL : `/projects/:id/packages/generic/:package_name/:package_version/:file_name`

I added the ability to provide a custom package name through the optional `packageName` property.

Usage example:
```
{
  "branches": ["main"],
  "plugins": [
    "@semantic-release/commit-analyzer",
    "@semantic-release/release-notes-generator",
    [
      "@semantic-release/gitlab",
      {
        "gitlabUrl": "https://custom.gitlab.com",
        "assets": [
          { "path": "dist/asset.min.js", "label": "JS distribution", "target": "generic_package", "packageName": "styles" },
        ]
      }
    ]
  ]
}
```
This will create a new `styles` package in the Gitlab package repository with the specified files. 