### PR TITLE
fix(generix-package): add missing fallback for label #823

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -108,8 +108,9 @@ export default async (pluginConfig, context) => {
           let response;
 
           if (target === "generic_package") {
+            const finalLabel = label ?? pathlib.basename(file);
             // Upload generic packages
-            const encodedLabel = encodeURIComponent(label);
+            const encodedLabel = encodeURIComponent(finalLabel);
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
             uploadEndpoint = urlJoin(
               projectApiUrl,
@@ -130,7 +131,7 @@ export default async (pluginConfig, context) => {
             // https://docs.gitlab.com/ee/user/packages/generic_packages/#download-package-file
             const url = urlJoin(projectApiUrl, `packages/generic/release/${encodedVersion}/${encodedLabel}`);
 
-            assetsList.push({ label, alt: "release", url, type: "package", filepath });
+            assetsList.push({ label: finalLabel, alt: "release", url, type: "package", filepath });
 
             logger.log("Uploaded file: %s (%s)", url, response.file.url);
           } else {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -176,6 +176,52 @@ test.serial("Publish a release with generics", async (t) => {
   t.true(gitlab.isDone());
 });
 
+test.serial("Publish a release with generics (without label - issue #823)", async (t) => {
+  const cwd = "test/fixtures/files";
+  const owner = "test_user";
+  const repo = "test_repo";
+  const env = { GITLAB_TOKEN: "gitlab_token" };
+  const nextRelease = { gitHead: "123", gitTag: "v1.0.0", notes: "Test release note body", version: "1.0.0" };
+  const options = { repositoryUrl: `https://gitlab.com/${owner}/${repo}.git` };
+  const encodedProjectPath = encodeURIComponent(`${owner}/${repo}`);
+  const encodedGitTag = encodeURIComponent(nextRelease.gitTag);
+  const encodedVersion = encodeURIComponent(nextRelease.version);
+  const uploaded = { file: { url: "/uploads/file.css" } };
+  const generic = { path: "file.css", target: "generic_package", status: "hidden" };
+  const assets = [generic];
+  const encodedLabel = encodeURIComponent(generic.path);
+  const expectedUrl = `https://gitlab.com/api/v4/projects/${encodedProjectPath}/packages/generic/release/${encodedVersion}/${encodedLabel}`;
+  const gitlab = authenticate(env)
+    .post(`/projects/${encodedProjectPath}/releases`, {
+      tag_name: nextRelease.gitTag,
+      description: nextRelease.notes,
+      assets: {
+        links: [
+          {
+            name: "file.css",
+            url: expectedUrl,
+            link_type: "package",
+          },
+        ],
+      },
+    })
+    .reply(200);
+  const gitlabUpload = authenticate(env)
+    .put(
+      `/projects/${encodedProjectPath}/packages/generic/release/${encodedVersion}/${encodedLabel}?status=${generic.status}&select=package_file`,
+      /\.test\s\{\}/gm
+    )
+    .reply(200, uploaded);
+
+  const result = await publish({ assets }, { env, cwd, options, nextRelease, logger: t.context.logger });
+
+  t.is(result.url, `https://gitlab.com/${owner}/${repo}/-/releases/${encodedGitTag}`);
+  t.deepEqual(t.context.log.args[0], ["Uploaded file: %s (%s)", expectedUrl, uploaded.file.url]);
+  t.deepEqual(t.context.log.args[1], ["Published GitLab release: %s", nextRelease.gitTag]);
+  t.true(gitlabUpload.isDone());
+  t.true(gitlab.isDone());
+});
+
 test.serial("Publish a release with generics and external storage provider (http)", async (t) => {
   const cwd = "test/fixtures/files";
   const owner = "test_user";


### PR DESCRIPTION
This should fix #823 while adding the file basename fallback for a label as the description in the README highlights.
