### PR TITLE
fix: header must be a string, not array

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -31,7 +31,7 @@ export default async (pluginConfig, context) => {
   const { encodedProjectPath, projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
 
   const apiOptions = {
-    headers: { [tokenHeader]: gitlabToken },
+    headers: { tokenHeader: gitlabToken },
     retry: {
       limit: retryLimit,
       statusCodes: retryStatusCodes,

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -30,7 +30,7 @@ export default async (pluginConfig, context) => {
   const encodedGitTag = encodeURIComponent(gitTag);
   const apiOptions = {
     headers: {
-      [tokenHeader]: gitlabToken,
+      tokenHeader: gitlabToken,
     },
     hooks: {
       beforeError: [

--- a/lib/success.js
+++ b/lib/success.js
@@ -29,7 +29,7 @@ export default async (pluginConfig, context) => {
   } = resolveConfig(pluginConfig, context);
   const { projectApiUrl } = getProjectContext(context, gitlabUrl, gitlabApiUrl, repositoryUrl);
   const apiOptions = {
-    headers: { [tokenHeader]: gitlabToken },
+    headers: { tokenHeader: gitlabToken },
     retry: { limit: retryLimit, statusCodes: retryStatusCodes },
   };
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -66,13 +66,13 @@ export default async (pluginConfig, context) => {
     try {
       if (useJobToken) {
         logger.log("Using Job Token for authentication. Some functionality may be disabled.");
-        await got.get(urlJoin(projectApiUrl, "releases"), { headers: { [tokenHeader]: gitlabToken } });
+        await got.get(urlJoin(projectApiUrl, "releases"), { headers: { tokenHeader: gitlabToken } });
       } else {
         ({
           permissions: { project_access: projectAccess, group_access: groupAccess },
         } = await got
           .get(projectApiUrl, {
-            headers: { [tokenHeader]: gitlabToken },
+            headers: { tokenHeader: gitlabToken },
             ...proxy,
           })
           .json());

--- a/test/helpers/mock-gitlab.js
+++ b/test/helpers/mock-gitlab.js
@@ -26,5 +26,5 @@ export default function (
   const tokenHeader = useJobToken ? "JOB-TOKEN" : "Private-Token";
   const token = useJobToken ? env.CI_JOB_TOKEN : gitlabToken;
 
-  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), { reqheaders: { [tokenHeader]: token } });
+  return nock(urlJoin(gitlabUrl, gitlabApiPathPrefix), { reqheaders: { tokenHeader: token } });
 }


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/candrews'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/candrews/tally.svg'></a>

The header must be a string, not an array. Per the got documentation, `headers` is of type `object<string, string>`. See https://github.com/sindresorhus/got/blob/v14.6.6/documentation/2-options.md#headers

This PR fixes the mis-typing problem introduced in https://github.com/semantic-release/gitlab/pull/919 which appears to cause GitLab releases to fail with incorrect `EINVALIDGLTOKEN Invalid GitLab token.` errors.

@arvest-bjoneson @fgreinacher